### PR TITLE
feat: icon-forward command card layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Command Cards: icon-forward layout** — Each command card now displays a large 42×42px icon block on the left (showing the card's emoji or lucide icon), with the title, command text, and Paste/Run buttons in a compact column to the right. The title size is reduced to better balance the prominent icon. Favorites now show an inline star indicator. The card height is reduced — more cards fit on screen at once.
+
 ## [7.0.0] - 2026-04-17
 
 ---

--- a/frontend/src/components/SortableCommandCard.jsx
+++ b/frontend/src/components/SortableCommandCard.jsx
@@ -1,7 +1,10 @@
+// SortableCommandCard renders a single draggable command card with a large
+// icon on the left and title/command/actions stacked in a column on the right.
+// This mirrors the mockup layout: prominent icon → compact text → Paste + Run.
 import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Play, Clipboard, Edit2, Trash2, GripVertical } from 'lucide-react';
+import { Play, Clipboard, Edit2, Trash2, GripVertical, Zap } from 'lucide-react';
 import { iconMap, getEmojiFromIcon } from './IconPicker';
 
 export function SortableCommandCard({ command, onExecute, onPaste, onEdit, onDelete }) {
@@ -14,76 +17,111 @@ export function SortableCommandCard({ command, onExecute, onPaste, onEdit, onDel
         isDragging,
     } = useSortable({ id: command.id });
 
-    const style = {
+    const dragStyle = {
         transform: CSS.Transform.toString(transform),
         transition,
         zIndex: isDragging ? 999 : 'auto',
     };
 
-    // Get icon - check if it's an emoji first (either legacy or direct unicode)
+    // Resolve icon: emoji takes priority over lucide icon map, fallback to Zap
     const emojiChar = getEmojiFromIcon(command.icon);
-    const CommandIcon = !emojiChar && command.icon ? iconMap[command.icon] : null;
+    const LucideIcon = !emojiChar && command.icon ? iconMap[command.icon] : null;
+    const hasFallbackIcon = !emojiChar && !LucideIcon;
 
     return (
         <div
             ref={setNodeRef}
-            style={style}
+            style={dragStyle}
             className={`card ${isDragging ? 'dragging' : ''} ${command.favorite ? 'favorite' : ''} ${command.alwaysAppend ? 'always-append' : ''}`}
         >
-            <div className="card-header">
-                <div className="card-title-row">
-                    {command.keyBinding && (
-                        <span className="keybinding-badge">{command.keyBinding}</span>
-                    )}
-                    {command.alwaysAppend && (
-                        <span className="always-append-badge" title="This text is appended to every prompt">📌</span>
-                    )}
-                    <span className="card-title">{command.name}</span>
-                </div>
+            {/* ── Large icon block on the left ── */}
+            <div className="card-icon-block">
+                {emojiChar && <span>{emojiChar}</span>}
+                {LucideIcon && <LucideIcon size={22} />}
+                {hasFallbackIcon && <Zap size={22} />}
+            </div>
 
-                <div className="card-actions-top">
-                    {command.alwaysAppend && (
-                        <div className="action-icon always-append-indicator" title="Always Append - Appended to every prompt" style={{ color: '#f59e0b' }}>
-                            <span style={{ fontSize: '12px', fontWeight: 700 }}>A+</span>
+            {/* ── Main content: title row → command text → action buttons ── */}
+            <div className="card-content-column">
+
+                {/* Title row: name + keybinding badge + favorite star + hover actions */}
+                <div className="card-header">
+                    <div className="card-title-row">
+                        <span className="card-title">{command.name}</span>
+                        {command.keyBinding && (
+                            <span className="keybinding-badge">{command.keyBinding}</span>
+                        )}
+                        {command.alwaysAppend && (
+                            <span className="always-append-badge" title="Appended to every prompt">📌</span>
+                        )}
+                        {command.favorite && (
+                            <span className="card-favorite-star" title="Favorite">★</span>
+                        )}
+                    </div>
+
+                    {/* Edit/delete/drag icons — revealed on card hover */}
+                    <div className="card-actions-top">
+                        {command.alwaysAppend && (
+                            <div
+                                className="action-icon always-append-indicator"
+                                title="Always Append — added to every prompt"
+                                style={{ color: '#f59e0b' }}
+                            >
+                                <span style={{ fontSize: '11px', fontWeight: 700 }}>A+</span>
+                            </div>
+                        )}
+                        <div
+                            {...attributes}
+                            {...listeners}
+                            className="action-icon"
+                            style={{ cursor: 'grab' }}
+                            title="Drag to reorder"
+                        >
+                            <GripVertical size={16} />
                         </div>
-                    )}
-                    <div {...attributes} {...listeners} className="action-icon" style={{ cursor: 'grab' }} title="Drag to reorder">
-                        <GripVertical size={18} />
-                    </div>
-                    <div className="action-icon" onClick={(e) => { e.stopPropagation(); onEdit(command); }} title="Edit Command">
-                        <Edit2 size={18} />
-                    </div>
-                    <div className="action-icon delete" onClick={(e) => { e.stopPropagation(); onDelete(command.id); }} title="Delete Command">
-                        <Trash2 size={18} />
+                        <div
+                            className="action-icon"
+                            onClick={(editEvent) => { editEvent.stopPropagation(); onEdit(command); }}
+                            title="Edit"
+                        >
+                            <Edit2 size={16} />
+                        </div>
+                        <div
+                            className="action-icon delete"
+                            onClick={(deleteEvent) => { deleteEvent.stopPropagation(); onDelete(command.id); }}
+                            title="Delete"
+                        >
+                            <Trash2 size={16} />
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div className="card-body">
-                <div className="command-preview" title={command.command}>
-                    {emojiChar && <span className="command-icon" style={{ fontSize: '18px', marginRight: '8px' }}>{emojiChar}</span>}
-                    {CommandIcon && <CommandIcon size={18} className="command-icon" />}
-                    {command.description || command.command}
+                {/* Command or description text — shown in monospace as a code hint */}
+                <div className="card-body">
+                    <div className="command-preview" title={command.command}>
+                        {command.description || command.command}
+                    </div>
                 </div>
-            </div>
 
-            <div className={`card-footer ${command.pasteOnly ? 'paste-only' : ''}`}>
-                <button
-                    className="btn-action btn-paste"
-                    onClick={() => onPaste(command)}
-                    title="Paste to Terminal"
-                >
-                    <Clipboard size={16} /> Paste
-                </button>
-                {!command.pasteOnly && (
+                {/* Paste + Run buttons */}
+                <div className={`card-footer ${command.pasteOnly ? 'paste-only' : ''}`}>
                     <button
-                        className="btn-action btn-run"
-                        onClick={() => onExecute(command)}
-                        title="Run in Terminal"
+                        className="btn-action btn-paste"
+                        onClick={() => onPaste(command)}
+                        title="Paste to Terminal"
                     >
-                        <Play size={16} /> Run
+                        <Clipboard size={14} /> Paste
                     </button>
-                )}
+                    {!command.pasteOnly && (
+                        <button
+                            className="btn-action btn-run"
+                            onClick={() => onExecute(command)}
+                            title="Run in Terminal"
+                        >
+                            <Play size={14} /> Run
+                        </button>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -403,24 +403,29 @@ body {
   color: var(--red);
 }
 
-/* Card Styles */
+/* ── Card: horizontal layout — large icon left, content column right ── */
 .card {
   background: var(--card-bg);
   background-image: var(--gradient-card);
   border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 12px;
+  padding: 11px 12px;
+  margin-bottom: 8px;
   border: 1px solid var(--card-border);
   box-shadow: var(--shadow-sm);
   transition: all 0.2s ease;
   position: relative;
   overflow: hidden;
+  /* Side-by-side: icon block | content column */
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 11px;
 }
 
 .card:hover {
   border-color: var(--card-hover-border);
   box-shadow: var(--shadow-glow), var(--shadow-md);
-  transform: translateY(-2px);
+  transform: translateY(-1px);
 }
 
 /* Dragging state */
@@ -436,47 +441,89 @@ body {
 }
 
 .always-append-badge {
-  font-size: 14px;
-  margin-right: 4px;
+  font-size: 12px;
+}
+
+/* ── Large icon block — the prominent visual anchor on the left ── */
+.card-icon-block {
+  width: 42px;
+  height: 42px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.45rem;
+  flex-shrink: 0;
+  /* Use overlay background so it reads in all 6 themes */
+  background: var(--overlay);
+  border: 1px solid var(--card-border);
+  color: var(--accent);
+  /* Nudge icon block down slightly to align with title text baseline */
+  margin-top: 1px;
+}
+
+/* ── Content column: title row → command text → action buttons ── */
+.card-content-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 12px;
+  align-items: center;
+  /* No bottom margin — the column gap handles spacing */
 }
 
+/* Title row: name + optional keybinding badge + favorite star */
 .card-title-row {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
 }
 
 .keybinding-badge {
   background: var(--gradient-primary);
   color: #fff;
-  font-size: 0.85rem;
+  font-size: 0.65rem;
   font-weight: 700;
-  padding: 4px 8px;
-  border-radius: 6px;
+  padding: 2px 5px;
+  border-radius: 5px;
   display: inline-block;
-  align-self: flex-start;
+  flex-shrink: 0;
   box-shadow: var(--shadow-glow);
 }
 
 .card-title {
-  font-weight: 700;
-  font-size: 1.3rem;
+  font-weight: 600;
+  font-size: 0.85rem;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Favorite star — shown inline when the command is starred */
+.card-favorite-star {
+  color: var(--accent);
+  font-size: 0.65rem;
+  flex-shrink: 0;
+  opacity: 0.9;
 }
 
 .card-actions-top {
   display: flex;
-  gap: 4px;
+  gap: 2px;
   opacity: 0;
-  /* Hide by default, show on hover */
+  /* Hidden by default, revealed on card hover */
   transition: opacity 0.2s;
+  flex-shrink: 0;
 }
 
 .card:hover .card-actions-top {
@@ -486,7 +533,7 @@ body {
 .action-icon {
   color: var(--subtext);
   cursor: pointer;
-  padding: 4px;
+  padding: 3px;
   border-radius: 4px;
   transition: color 0.2s, background 0.2s;
 }
@@ -501,41 +548,41 @@ body {
   background: rgba(243, 139, 168, 0.1);
 }
 
+/* ── Command preview text ── */
 .card-body {
-  margin-bottom: 16px;
+  /* No extra margin needed — gap on .card-content-column handles spacing */
 }
 
 .command-preview {
   display: block;
   font-family: 'JetBrains Mono', monospace;
-  /* Assuming font availability or fallback */
-  font-size: 1.1rem;
+  font-size: 0.72rem;
   font-weight: 500;
   color: var(--subtext);
   background: rgba(0, 0, 0, 0.2);
-  padding: 8px 10px;
-  border-radius: 6px;
+  padding: 5px 8px;
+  border-radius: 5px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
+/* ── Paste / Run button row ── */
 .card-footer {
   display: flex;
-  gap: 8px;
+  gap: 6px;
 }
 
 .card-footer.paste-only .btn-action {
   flex: 1;
-  /* Full width if only one button */
 }
 
 .btn-action {
-  padding: 8px;
+  padding: 5px 10px;
   border-radius: 6px;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.75rem;
   cursor: pointer;
   border: 1px solid var(--overlay);
   background: transparent;
@@ -544,25 +591,24 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 5px;
 }
 
+/* Paste: outlined accent — secondary action */
 .btn-paste {
-  flex: 2;
-  /* 20% roughly, relative to flex: 8 */
+  flex: 1;
   border-color: var(--accent);
-  box-shadow: 0 0 8px rgba(249, 115, 22, 0.2);
-  /* Subtle glow */
+  box-shadow: 0 0 6px rgba(249, 115, 22, 0.15);
 }
 
 .btn-paste:hover {
   background: rgba(249, 115, 22, 0.1);
-  box-shadow: 0 0 12px rgba(249, 115, 22, 0.4);
+  box-shadow: 0 0 12px rgba(249, 115, 22, 0.35);
 }
 
+/* Run: filled gradient — primary CTA */
 .btn-run {
-  flex: 8;
-  /* 80% */
+  flex: 3;
   background: var(--gradient-primary);
   color: #fff;
   border: none;


### PR DESCRIPTION
## Summary
Redesigns command cards to match the marketing mockup style: a large prominent icon block on the left with title, command text, and Paste/Run buttons in a compact column to the right.

## Changes
- \SortableCommandCard.jsx\ — restructured JSX from vertical 3-section to horizontal icon+content layout; icon moved from inline command-preview to a standalone 42px block
- \index.css\ — updated \.card\ to \display: flex; flex-direction: row\; added \.card-icon-block\ and \.card-content-column\; reduced \.card-title\ from 1.3rem → 0.85rem; trimmed \.command-preview\ to 0.72rem; adjusted Paste/Run button sizing to 1:3 flex ratio
- \CHANGELOG.md\ — updated Unreleased section

## Visual Result
Each card now shows the emoji/icon large and prominent on the left. The Paste + Run buttons are still fully visible and functional. Favorites show an inline star. Cards are more compact — more fit on screen.

## Verified
- \
px vite build\ ✅ built in 2.90s (no errors)