### PR TITLE
feat: add environment_detect and environment_run MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`environment_detect` MCP tool** — agents can probe the host for WSL2 and Docker availability before choosing an execution strategy. Returns `wsl2_available`, `docker_available`, `docker_installed_but_not_running`, `recommended` strategy, and an `install_hint` when neither is configured.
+- **`environment_run` MCP tool** — agents can run shell commands in `native`, `linux-wsl`, `linux-docker`, or `auto` environments. Solves Windows build incompatibilities (Turbopack/OpenNext chunk filename issues) without requiring GitHub Actions workflows or CI secrets. Supports configurable timeouts up to 10 minutes for long builds. Returns `exit_code`, `stdout`, `stderr`, `environment_used`, and `duration_seconds`.
+
 ## [7.2.8] - 2026-04-20
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **`environment_detect` MCP tool** — agents can probe the host for WSL2 and Docker availability before choosing an execution strategy. Returns `wsl2_available`, `docker_available`, `docker_installed_but_not_running`, `recommended` strategy, and an `install_hint` when neither is configured.
+### Fixed
+- **Code Tutor toast leak** — `EnterpriseWorkflowCard` was firing blank toast notifications via a leftover file-watcher effect even though Code Tutor is disabled. The watcher start/stop lifecycle and the broken notification effect have been removed entirely; the polling loop no longer runs.
+- **Code Tutor options in Workflow Wizard** — `tutor` and `tutor-and-agent` PR review strategy cards have been removed from the Enterprise Workflow Wizard. Users who had those strategies saved will be automatically migrated to `agent` on next open. Quality Agent is now the recommended strategy.
+
+— agents can probe the host for WSL2 and Docker availability before choosing an execution strategy. Returns `wsl2_available`, `docker_available`, `docker_installed_but_not_running`, `recommended` strategy, and an `install_hint` when neither is configured.
 - **`environment_run` MCP tool** — agents can run shell commands in `native`, `linux-wsl`, `linux-docker`, or `auto` environments. Solves Windows build incompatibilities (Turbopack/OpenNext chunk filename issues) without requiring GitHub Actions workflows or CI secrets. Supports configurable timeouts up to 10 minutes for long builds. Returns `exit_code`, `stdout`, `stderr`, `environment_used`, and `duration_seconds`.
 
 ## [7.2.8] - 2026-04-20

--- a/frontend/src/components/EnterpriseWorkflowCard.jsx
+++ b/frontend/src/components/EnterpriseWorkflowCard.jsx
@@ -14,9 +14,8 @@ import './EnterpriseWorkflowCard.css'
  * @param {Function} props.onExecuteCommand - Send a command to the terminal
  * @param {Function} props.onToast - Show a toast notification
  * @param {string} props.cwd - Current working directory (project path)
-// onOpenTutor removed — Code Tutor fully disabled
  */
-const EnterpriseWorkflowCard = ({ onExecuteCommand, onToast, cwd }) => { // onOpenTutor removed — Code Tutor fully disabled
+const EnterpriseWorkflowCard = ({ onExecuteCommand, onToast, cwd }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [wizardOpen, setWizardOpen] = useState(false)
   const [showFindings, setShowFindings] = useState(false)
@@ -28,10 +27,6 @@ const EnterpriseWorkflowCard = ({ onExecuteCommand, onToast, cwd }) => { // onOp
     compliance,
     checkStatus,
     scanCompliance,
-    watcherNotifications,
-    startWatcher,
-    stopWatcher,
-    clearWatcherNotifications,
   } = workflow
 
   // Auto-check status when cwd changes
@@ -48,44 +43,8 @@ const EnterpriseWorkflowCard = ({ onExecuteCommand, onToast, cwd }) => { // onOp
     }
   }, [status?.configured, cwd, scanCompliance])
 
-  // Code Tutor watcher logic removed — Code Tutor fully disabled
-  useEffect(() => {
-    if (status?.configured && cwd) {
-      startWatcher(cwd)
-    }
 
-    return () => {
-      if (cwd) {
-        stopWatcher(cwd)
-      }
-    }
-  }, [status?.configured, cwd, startWatcher, stopWatcher])
-
-  // Show toast notifications when the watcher detects file changes, then immediately
-  // clear the queue so the same notifications aren't re-shown on the next render.
-  // Code Tutor action button removed — Code Tutor fully disabled
-  useEffect(() => {
-    if (watcherNotifications.length === 0) return
-
-    watcherNotifications.forEach((notification) => {
-      if (onToast) {
-        onToast(
-          // Code Tutor notification removed — Code Tutor fully disabled
-          'info',
-          8000, // Extended duration — user needs time to read and decide whether to click
-          {
-            // Code Tutor action removed — Code Tutor fully disabled
-            // onOpenTutor removed — Code Tutor fully disabled
-          }
-        )
-      }
-    })
-
-    // Flush the queue atomically so these notifications aren't shown again
-    clearWatcherNotifications()
-  }, [watcherNotifications, onToast, clearWatcherNotifications]) // onOpenTutor removed — Code Tutor fully disabled
-
-  const handleRefresh = useCallback(async () => {
+  const handleRefresh= useCallback(async () => {
     if (!cwd || isRefreshing) return
     setIsRefreshing(true)
     try {

--- a/frontend/src/components/WorkflowWizard.jsx
+++ b/frontend/src/components/WorkflowWizard.jsx
@@ -16,7 +16,6 @@ import {
   SkipForward,
   Shield,
   Zap,
-  BookOpen,
   GitBranch,
   TestTube,
   FileCheck,
@@ -533,15 +532,16 @@ function StepConfigure({ config, moduleCatalog, onToggleModule, onSetQualityMode
 /**
  * StepPRReview lets the user choose how pull requests will be reviewed.
  *
- * Four strategies are available:
+ * Two strategies are available:
  * - manual: user inspects diffs themselves
- * - tutor: Code Tutor explains each changed file with streaming walkthroughs
  * - agent: Quality Agent posts structured findings (naming, tests, architecture)
- * - tutor-and-agent: both run in parallel (recommended for enterprise)
  */
 function StepPRReview({ config, onUpdateConfig }) {
-  // Which strategy cards are currently shown as selected
-  const selectedStrategy = config.prReviewStrategy || 'agent' // Code Tutor strategies removed
+  // Coerce legacy tutor strategies (saved before Code Tutor was removed) to 'agent'.
+  const rawStrategy = config.prReviewStrategy || 'agent'
+  const selectedStrategy = (rawStrategy === 'tutor' || rawStrategy === 'tutor-and-agent')
+    ? 'agent'
+    : rawStrategy
 
   const reviewStrategies = [
     {
@@ -552,25 +552,11 @@ function StepPRReview({ config, onUpdateConfig }) {
       description: 'Review diffs yourself. No AI assistance.',
     },
     {
-      id: 'tutor',
-      label: 'Code Tutor',
-      icon: BookOpen,
-      color: '#3b82f6',
-      description: 'Code Tutor auto-explains each changed file with toast notifications and streaming walkthroughs.',
-    },
-    {
       id: 'agent',
       label: 'Quality Agent',
       icon: Bot,
       color: '#10b981',
       description: 'A dedicated AI reviewer analyzes the diff and posts structured findings: naming, complexity, tests, architecture, security.',
-    },
-    {
-      id: 'tutor-and-agent',
-      label: 'Tutor + Agent',
-      icon: Users,
-      color: '#8b5cf6',
-      description: 'Best of both: Code Tutor explains changes to you while the Quality Agent performs an automated review in parallel. Recommended.',
       isRecommended: true,
     },
   ]
@@ -593,7 +579,7 @@ function StepPRReview({ config, onUpdateConfig }) {
     onUpdateConfig({ prReviewAgentFocusAreas: updatedAreas })
   }, [selectedFocusAreas, onUpdateConfig])
 
-  const hasAgentComponent = selectedStrategy === 'agent' // Code Tutor strategies removed
+  const hasAgentComponent = selectedStrategy === 'agent'
 
   return (
     <div className="ww-step-content">

--- a/internal/mcp/environment_runner.go
+++ b/internal/mcp/environment_runner.go
@@ -1,0 +1,355 @@
+// environment_runner.go provides the CommandRunner interface and the platform
+// detection + execution logic that powers the environment_detect and
+// environment_run MCP tools.
+//
+// Three execution strategies are supported:
+//   - native     — runs the command in the host OS shell (cmd.exe on Windows, bash elsewhere)
+//   - linux-wsl  — runs the command inside WSL2 via wsl.exe, converting Windows paths to /mnt/
+//   - linux-docker — runs the command in an ephemeral Docker container with the project mounted
+//
+// The "auto" strategy probes availability and picks the best Linux option,
+// falling back to native when neither WSL2 nor Docker is reachable.
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const (
+	// DefaultDockerImage is used when the caller does not specify an image.
+	// node:lts covers the most common use case: JavaScript/TypeScript builds.
+	DefaultDockerImage = "node:lts"
+
+	// defaultEnvironmentTimeoutSec is used when the caller omits timeout_seconds.
+	// 120 seconds covers most npm installs and incremental builds.
+	defaultEnvironmentTimeoutSec = 120
+
+	// maxEnvironmentTimeoutSec is the hard upper limit — 10 minutes for large builds.
+	maxEnvironmentTimeoutSec = 600
+
+	// wslExecutable is the WSL2 launcher binary on Windows.
+	wslExecutable = "wsl.exe"
+
+	// dockerExecutable is the Docker CLI binary name.
+	dockerExecutable = "docker"
+
+	// dockerInfoSubcommand probes whether the Docker daemon is reachable.
+	dockerInfoSubcommand = "info"
+
+	// dockerVersionSubcommand probes whether the Docker binary is installed
+	// (succeeds even when the daemon is not running).
+	dockerVersionSubcommand = "--version"
+
+	// wslStatusSubcommand probes whether WSL2 is installed and configured.
+	wslStatusSubcommand = "--status"
+)
+
+// ── Environment Strategy Names ────────────────────────────────────────────────
+
+// These constants are the valid values for the environment_run "environment" argument.
+const (
+	StrategyAuto        = "auto"
+	StrategyNative      = "native"
+	StrategyLinuxWSL    = "linux-wsl"
+	StrategyLinuxDocker = "linux-docker"
+)
+
+// ── CommandRunner Interface ───────────────────────────────────────────────────
+
+// CommandRunner abstracts OS process execution.
+// All environment tools use this interface so unit tests can inject a mock
+// without spawning real processes or requiring WSL2 / Docker to be installed.
+type CommandRunner interface {
+	// RunCommand executes the named binary with the given arguments.
+	// A non-zero ExitCode in the returned RunOutput is NOT an error —
+	// it means the command ran but reported failure. Only process-level
+	// failures (binary not found, permission denied) return a non-nil error.
+	RunCommand(ctx context.Context, name string, args []string) (RunOutput, error)
+}
+
+// RunOutput holds the result of a single command execution.
+type RunOutput struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// ── Real CommandRunner ─────────────────────────────────────────────────────────
+
+// realCommandRunner executes commands using the OS process API.
+// Tests use mockCommandRunner or testCommandRunner instead.
+type realCommandRunner struct{}
+
+// RunCommand forks a child process, captures stdout and stderr separately,
+// and returns them along with the exit code.
+func (r *realCommandRunner) RunCommand(ctx context.Context, name string, args []string) (RunOutput, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	cmd.Stderr = &stderrBuffer
+
+	runErr := cmd.Run()
+
+	output := RunOutput{
+		Stdout: stdoutBuffer.String(),
+		Stderr: stderrBuffer.String(),
+	}
+
+	if runErr != nil {
+		// Distinguish between "command exited non-zero" and "command could not start".
+		if exitErr, isExitError := runErr.(*exec.ExitError); isExitError {
+			output.ExitCode = exitErr.ExitCode()
+			return output, nil // Non-zero exit is reported via ExitCode, not error.
+		}
+		return output, fmt.Errorf("could not execute %q: %w", name, runErr)
+	}
+
+	return output, nil
+}
+
+// ── Environment Availability ──────────────────────────────────────────────────
+
+// EnvironmentAvailability reports which Linux execution environments are
+// reachable on the current machine. The Recommended field gives agents a
+// single concrete strategy to use without needing to interpret the flags.
+type EnvironmentAvailability struct {
+	WSL2Available                bool   `json:"wsl2_available"`
+	DockerAvailable              bool   `json:"docker_available"`
+	DockerInstalledButNotRunning bool   `json:"docker_installed_but_not_running"`
+	Recommended                  string `json:"recommended"`
+	InstallHint                  string `json:"install_hint,omitempty"`
+}
+
+// detectAvailableEnvironments probes the host for WSL2 and Docker.
+// Detection happens at call time so the result reflects the current runtime
+// state — not a snapshot from server startup.
+func detectAvailableEnvironments(runner CommandRunner) EnvironmentAvailability {
+	// Use a short probe timeout so a hung daemon doesn't block the caller.
+	probeCtx, cancelProbe := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelProbe()
+
+	availability := EnvironmentAvailability{}
+
+	// WSL2 probe: wsl.exe --status exits 0 when WSL2 is installed and configured.
+	wslOutput, wslErr := runner.RunCommand(probeCtx, wslExecutable, []string{wslStatusSubcommand})
+	availability.WSL2Available = wslErr == nil && wslOutput.ExitCode == 0
+
+	// Docker daemon probe: docker info exits 0 only when the daemon is reachable.
+	dockerInfoOutput, dockerInfoErr := runner.RunCommand(probeCtx, dockerExecutable, []string{dockerInfoSubcommand})
+	availability.DockerAvailable = dockerInfoErr == nil && dockerInfoOutput.ExitCode == 0
+
+	if !availability.DockerAvailable {
+		// Secondary probe: docker --version succeeds even when the daemon is down.
+		// This distinguishes "not installed" from "installed but daemon not running".
+		versionOutput, versionErr := runner.RunCommand(probeCtx, dockerExecutable, []string{dockerVersionSubcommand})
+		if versionErr == nil && versionOutput.ExitCode == 0 {
+			availability.DockerInstalledButNotRunning = true
+			availability.InstallHint = "Start Docker Desktop from your system tray or Start menu."
+		} else {
+			availability.InstallHint = "Install Docker Desktop from https://www.docker.com/products/docker-desktop"
+		}
+	}
+
+	availability.Recommended = resolveRecommendedStrategy(availability)
+	return availability
+}
+
+// resolveRecommendedStrategy picks the best concrete strategy given availability.
+// WSL2 is preferred over Docker because it starts instantly with no container overhead.
+// Docker is the standard fallback for Windows machines without WSL2.
+func resolveRecommendedStrategy(availability EnvironmentAvailability) string {
+	if availability.WSL2Available {
+		return StrategyLinuxWSL
+	}
+	if availability.DockerAvailable {
+		return StrategyLinuxDocker
+	}
+	return StrategyNative
+}
+
+// ── Strategy Resolution ───────────────────────────────────────────────────────
+
+// resolveConcreteStrategy converts "auto" to a specific strategy by probing
+// availability. Non-auto strategies are returned unchanged.
+func resolveConcreteStrategy(requested string, runner CommandRunner) string {
+	if requested != StrategyAuto {
+		return requested
+	}
+	availability := detectAvailableEnvironments(runner)
+	return availability.Recommended
+}
+
+// ── WSL Path Conversion ───────────────────────────────────────────────────────
+
+// convertWindowsPathToWSLMount converts a Windows absolute path to the WSL2
+// mount path so Linux tools can access files on the Windows filesystem.
+//
+// Examples:
+//
+//	C:\Projects\foo   → /mnt/c/Projects/foo
+//	D:\Work\project\  → /mnt/d/Work/project
+func convertWindowsPathToWSLMount(windowsPath string) string {
+	// Normalise separators and strip any trailing separator.
+	normalised := strings.ReplaceAll(
+		strings.TrimRight(windowsPath, `\/`),
+		`\`, `/`,
+	)
+
+	// Windows drive paths begin with a letter followed by a colon (e.g. "C:/…").
+	// WSL mounts them at /mnt/<lowercase-letter>/<rest>.
+	if len(normalised) >= 2 && normalised[1] == ':' {
+		driveLetter := strings.ToLower(string(normalised[0]))
+		pathAfterDrive := normalised[2:] // everything after "C:"
+		return "/mnt/" + driveLetter + pathAfterDrive
+	}
+
+	// UNC paths and already-unix paths pass through unchanged.
+	return normalised
+}
+
+// ── Command Argument Builders ─────────────────────────────────────────────────
+
+// buildWSLCommandArgs constructs the wsl.exe argument list for running a shell
+// command inside WSL2 from a Windows working directory.
+func buildWSLCommandArgs(command, workingDirectory string) []string {
+	wslWorkingDirectory := convertWindowsPathToWSLMount(workingDirectory)
+
+	// cd to the converted path first so relative paths in the command resolve correctly.
+	shellScript := fmt.Sprintf("cd %s && %s", shellQuotePath(wslWorkingDirectory), command)
+	return []string{"-e", "bash", "-c", shellScript}
+}
+
+// buildDockerCommandArgs constructs the docker run argument list for running a
+// command in an ephemeral container with the project directory mounted.
+func buildDockerCommandArgs(command, workingDirectory, image string) []string {
+	if image == "" {
+		image = DefaultDockerImage
+	}
+
+	// --rm: remove the container when the command finishes (ephemeral, no cleanup needed).
+	// -v: mount the host working directory at /workspace inside the container.
+	// -w: set /workspace as the container's working directory.
+	return []string{
+		"run", "--rm",
+		"-v", workingDirectory + ":/workspace",
+		"-w", "/workspace",
+		image,
+		"bash", "-c", command,
+	}
+}
+
+// buildNativeCommandArgs returns the executable and arguments for running a
+// command in the host OS shell — cmd.exe on Windows, bash everywhere else.
+func buildNativeCommandArgs(command string) (executable string, args []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", command}
+	}
+	return "bash", []string{"-c", command}
+}
+
+// shellQuotePath wraps a filesystem path in single quotes and escapes any
+// embedded single quotes so the path is safe inside a bash -c argument.
+func shellQuotePath(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}
+
+// ── Execution ─────────────────────────────────────────────────────────────────
+
+// RunOptions holds all parameters for a single runInEnvironment call.
+type RunOptions struct {
+	Command          string
+	Environment      string // "auto" | "native" | "linux-wsl" | "linux-docker"
+	WorkingDirectory string
+	DockerImage      string
+}
+
+// EnvironmentRunResult carries the output of a completed environment run.
+type EnvironmentRunResult struct {
+	ExitCode        int     `json:"exit_code"`
+	Stdout          string  `json:"stdout"`
+	Stderr          string  `json:"stderr"`
+	EnvironmentUsed string  `json:"environment_used"`
+	DurationSeconds float64 `json:"duration_seconds"`
+}
+
+// runInEnvironment executes the command described by opts using the appropriate
+// strategy, returning structured output including the exit code and timing.
+func runInEnvironment(ctx context.Context, runner CommandRunner, opts RunOptions) (EnvironmentRunResult, error) {
+	startTime := time.Now()
+
+	strategy := resolveConcreteStrategy(opts.Environment, runner)
+
+	workingDirectory := opts.WorkingDirectory
+	if workingDirectory == "" {
+		// Fall back to the current process working directory when none is specified.
+		if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+			workingDirectory = cwd
+		}
+	}
+
+	var (
+		runOutput RunOutput
+		runErr    error
+	)
+
+	switch strategy {
+	case StrategyLinuxWSL:
+		wslArgs := buildWSLCommandArgs(opts.Command, workingDirectory)
+		runOutput, runErr = runner.RunCommand(ctx, wslExecutable, wslArgs)
+
+	case StrategyLinuxDocker:
+		dockerArgs := buildDockerCommandArgs(opts.Command, workingDirectory, opts.DockerImage)
+		runOutput, runErr = runner.RunCommand(ctx, dockerExecutable, dockerArgs)
+
+	default: // StrategyNative — also the fallback when "auto" finds nothing better
+		executable, nativeArgs := buildNativeCommandArgs(opts.Command)
+		runOutput, runErr = runner.RunCommand(ctx, executable, nativeArgs)
+		strategy = StrategyNative // Normalise "auto → native" for the result field.
+	}
+
+	if runErr != nil {
+		return EnvironmentRunResult{}, runErr
+	}
+
+	return EnvironmentRunResult{
+		ExitCode:        runOutput.ExitCode,
+		Stdout:          truncateKeepEnd(runOutput.Stdout, buildOutputMaxBytes),
+		Stderr:          truncateKeepEnd(runOutput.Stderr, buildOutputMaxBytes),
+		EnvironmentUsed: strategy,
+		DurationSeconds: time.Since(startTime).Seconds(),
+	}, nil
+}
+
+// buildOutputMaxBytes is the per-field cap for stdout and stderr in a run result.
+// Build output tends to be large; we keep the tail because errors appear at the end.
+const buildOutputMaxBytes = 20 * 1024 // 20 KiB per field
+
+// truncateKeepEnd returns up to maxBytes from the end of s.
+// When truncation occurs, a notice is prepended so the agent knows output was cut.
+func truncateKeepEnd(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	return "[output truncated — showing last portion]\n" + s[len(s)-maxBytes:]
+}
+
+// clampTimeout ensures the caller's requested timeout falls within 1–600 seconds.
+func clampTimeout(requestedSeconds int) int {
+	if requestedSeconds < 1 {
+		return 1
+	}
+	if requestedSeconds > maxEnvironmentTimeoutSec {
+		return maxEnvironmentTimeoutSec
+	}
+	return requestedSeconds
+}

--- a/internal/mcp/environment_runner_test.go
+++ b/internal/mcp/environment_runner_test.go
@@ -1,0 +1,312 @@
+// environment_runner_test.go tests the internal helper functions that power the
+// environment_run MCP tool — path conversion, command argument building, strategy
+// resolution, and timeout clamping.
+//
+// This file uses `package mcp` (not `package mcp_test`) so it can reach
+// unexported helpers without polluting the public API.
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// ── Mock CommandRunner ────────────────────────────────────────────────────────
+
+// mockCommandRunner is a test double for CommandRunner.
+// It records every call and returns canned responses keyed by executable name
+// so tests can verify what commands were built without spawning real processes.
+type mockCommandRunner struct {
+	responsesByExecutable map[string]RunOutput
+	recordedCalls         []recordedCommandCall
+}
+
+// recordedCommandCall captures a single RunCommand invocation for later assertion.
+type recordedCommandCall struct {
+	ExecutableName string
+	Arguments      []string
+}
+
+func newMockCommandRunner(responsesByExecutable map[string]RunOutput) *mockCommandRunner {
+	return &mockCommandRunner{
+		responsesByExecutable: responsesByExecutable,
+	}
+}
+
+func (m *mockCommandRunner) RunCommand(_ context.Context, name string, args []string) (RunOutput, error) {
+	m.recordedCalls = append(m.recordedCalls, recordedCommandCall{
+		ExecutableName: name,
+		Arguments:      args,
+	})
+	if output, hasOutput := m.responsesByExecutable[name]; hasOutput {
+		return output, nil
+	}
+	// Default: report failure so tests that don't configure a response catch misconfigured calls.
+	return RunOutput{ExitCode: 1, Stderr: "mock: no response configured for " + name}, nil
+}
+
+// ── WSL Path Conversion ───────────────────────────────────────────────────────
+
+func TestConvertWindowsPathToWSLMount_BasicPath(t *testing.T) {
+	input := `C:\Projects\foo`
+	want := `/mnt/c/Projects/foo`
+	got := convertWindowsPathToWSLMount(input)
+	if got != want {
+		t.Errorf("convertWindowsPathToWSLMount(%q) = %q; want %q", input, got, want)
+	}
+}
+
+func TestConvertWindowsPathToWSLMount_TrailingBackslash(t *testing.T) {
+	input := `C:\Projects\foo\`
+	want := `/mnt/c/Projects/foo`
+	got := convertWindowsPathToWSLMount(input)
+	if got != want {
+		t.Errorf("convertWindowsPathToWSLMount(%q) = %q; want %q", input, got, want)
+	}
+}
+
+func TestConvertWindowsPathToWSLMount_DriveLetterIsLowercased(t *testing.T) {
+	input := `D:\Work\project`
+	want := `/mnt/d/Work/project`
+	got := convertWindowsPathToWSLMount(input)
+	if got != want {
+		t.Errorf("convertWindowsPathToWSLMount(%q) = %q; want %q", input, got, want)
+	}
+}
+
+func TestConvertWindowsPathToWSLMount_NonDrivePath_PassesThrough(t *testing.T) {
+	input := `/already/unix/path`
+	got := convertWindowsPathToWSLMount(input)
+	if got != input {
+		t.Errorf("convertWindowsPathToWSLMount(%q) = %q; want passthrough %q", input, got, input)
+	}
+}
+
+// ── WSL Command Argument Building ─────────────────────────────────────────────
+
+func TestBuildWSLCommandArgs_HasCorrectShellPrefix(t *testing.T) {
+	args := buildWSLCommandArgs("npm run build", `C:\Projects\app`)
+
+	// The first three args must be: -e bash -c
+	if len(args) < 4 {
+		t.Fatalf("expected at least 4 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "-e" || args[1] != "bash" || args[2] != "-c" {
+		t.Errorf("expected args to start with [-e bash -c], got %v", args[:3])
+	}
+}
+
+func TestBuildWSLCommandArgs_ScriptContainsConvertedPath(t *testing.T) {
+	args := buildWSLCommandArgs("npm run build", `C:\Projects\app`)
+	script := args[3]
+	if !strings.Contains(script, "/mnt/c/Projects/app") {
+		t.Errorf("WSL script %q does not contain the converted Linux path /mnt/c/Projects/app", script)
+	}
+}
+
+func TestBuildWSLCommandArgs_ScriptContainsCommand(t *testing.T) {
+	args := buildWSLCommandArgs("npm run build", `C:\Projects\app`)
+	script := args[3]
+	if !strings.Contains(script, "npm run build") {
+		t.Errorf("WSL script %q does not contain the original command 'npm run build'", script)
+	}
+}
+
+// ── Docker Command Argument Building ──────────────────────────────────────────
+
+func TestBuildDockerCommandArgs_IncludesRemoveFlagForEphemeralContainer(t *testing.T) {
+	args := buildDockerCommandArgs("npm run build", `C:\Projects\app`, "node:lts")
+	if !containsStringInSlice(args, "--rm") {
+		t.Errorf("docker args must include --rm to ensure ephemeral containers; got: %v", args)
+	}
+}
+
+func TestBuildDockerCommandArgs_MountsWorkingDirectoryAtWorkspace(t *testing.T) {
+	cwd := `C:\Projects\app`
+	args := buildDockerCommandArgs("npm run build", cwd, "node:lts")
+	// The volume mount flag must bind cwd to /workspace.
+	expectedMount := cwd + ":/workspace"
+	if !containsStringInSlice(args, expectedMount) {
+		t.Errorf("expected mount arg %q in docker args; got: %v", expectedMount, args)
+	}
+}
+
+func TestBuildDockerCommandArgs_UsesProvidedDockerImage(t *testing.T) {
+	args := buildDockerCommandArgs("npm run build", `C:\Projects\app`, "node:18")
+	if !containsStringInSlice(args, "node:18") {
+		t.Errorf("expected image 'node:18' in docker args; got: %v", args)
+	}
+}
+
+func TestBuildDockerCommandArgs_DefaultsToNodeLTSWhenImageIsEmpty(t *testing.T) {
+	args := buildDockerCommandArgs("npm run build", `C:\Projects\app`, "")
+	if !containsStringInSlice(args, DefaultDockerImage) {
+		t.Errorf("expected default image %q in docker args when image is empty; got: %v", DefaultDockerImage, args)
+	}
+}
+
+func TestBuildDockerCommandArgs_SetsWorkingDirectoryInsideContainer(t *testing.T) {
+	args := buildDockerCommandArgs("npm run build", `C:\Projects\app`, "node:lts")
+	if !containsStringInSlice(args, "-w") {
+		t.Errorf("expected -w flag in docker args to set working directory; got: %v", args)
+	}
+	if !containsStringInSlice(args, "/workspace") {
+		t.Errorf("expected /workspace as working directory in docker args; got: %v", args)
+	}
+}
+
+// ── Strategy Resolution ───────────────────────────────────────────────────────
+
+func TestResolveRecommendedStrategy_PrefersWSL2WhenBothAvailable(t *testing.T) {
+	availability := EnvironmentAvailability{
+		WSL2Available:   true,
+		DockerAvailable: true,
+	}
+	got := resolveRecommendedStrategy(availability)
+	if got != StrategyLinuxWSL {
+		t.Errorf("expected %q when WSL2 and Docker are both available, got %q", StrategyLinuxWSL, got)
+	}
+}
+
+func TestResolveRecommendedStrategy_FallsBackToDockerWhenWSL2Unavailable(t *testing.T) {
+	availability := EnvironmentAvailability{
+		WSL2Available:   false,
+		DockerAvailable: true,
+	}
+	got := resolveRecommendedStrategy(availability)
+	if got != StrategyLinuxDocker {
+		t.Errorf("expected %q when only Docker is available, got %q", StrategyLinuxDocker, got)
+	}
+}
+
+func TestResolveRecommendedStrategy_FallsBackToNativeWhenNeitherAvailable(t *testing.T) {
+	availability := EnvironmentAvailability{
+		WSL2Available:   false,
+		DockerAvailable: false,
+	}
+	got := resolveRecommendedStrategy(availability)
+	if got != StrategyNative {
+		t.Errorf("expected %q when neither WSL2 nor Docker is available, got %q", StrategyNative, got)
+	}
+}
+
+// ── Timeout Clamping ──────────────────────────────────────────────────────────
+
+func TestClampTimeout_BelowMinimum_ClampsToOne(t *testing.T) {
+	if got := clampTimeout(0); got != 1 {
+		t.Errorf("clampTimeout(0) = %d; want 1", got)
+	}
+}
+
+func TestClampTimeout_NegativeValue_ClampsToOne(t *testing.T) {
+	if got := clampTimeout(-50); got != 1 {
+		t.Errorf("clampTimeout(-50) = %d; want 1", got)
+	}
+}
+
+func TestClampTimeout_AboveMaximum_ClampsToMax(t *testing.T) {
+	if got := clampTimeout(9999); got != maxEnvironmentTimeoutSec {
+		t.Errorf("clampTimeout(9999) = %d; want %d", got, maxEnvironmentTimeoutSec)
+	}
+}
+
+func TestClampTimeout_WithinRange_PassesThrough(t *testing.T) {
+	if got := clampTimeout(300); got != 300 {
+		t.Errorf("clampTimeout(300) = %d; want 300", got)
+	}
+}
+
+func TestClampTimeout_AtMinimumBoundary(t *testing.T) {
+	if got := clampTimeout(1); got != 1 {
+		t.Errorf("clampTimeout(1) = %d; want 1", got)
+	}
+}
+
+func TestClampTimeout_AtMaximumBoundary(t *testing.T) {
+	if got := clampTimeout(maxEnvironmentTimeoutSec); got != maxEnvironmentTimeoutSec {
+		t.Errorf("clampTimeout(%d) = %d; want %d", maxEnvironmentTimeoutSec, got, maxEnvironmentTimeoutSec)
+	}
+}
+
+// ── Docker Availability Detection ─────────────────────────────────────────────
+
+func TestDetectAvailableEnvironments_DockerAvailable_WhenInfoSucceeds(t *testing.T) {
+	runner := newMockCommandRunner(map[string]RunOutput{
+		dockerExecutable: {ExitCode: 0, Stdout: "Server: Docker Engine"},
+		wslExecutable:    {ExitCode: 1},
+	})
+
+	availability := detectAvailableEnvironments(runner)
+
+	if !availability.DockerAvailable {
+		t.Error("expected DockerAvailable=true when 'docker info' exits 0")
+	}
+}
+
+func TestDetectAvailableEnvironments_DockerInstalledButNotRunning_WhenInfoFailsVersionSucceeds(t *testing.T) {
+	// Simulate: `docker info` fails (daemon not running), but `docker --version` succeeds.
+	callCount := 0
+	runner := &callCountingMockRunner{
+		onRunCommand: func(name string, args []string) RunOutput {
+			if name == dockerExecutable {
+				callCount++
+				// First call is `docker info` (fails); second is `docker --version` (succeeds).
+				if callCount == 1 {
+					return RunOutput{ExitCode: 1, Stderr: "Cannot connect to Docker daemon"}
+				}
+				return RunOutput{ExitCode: 0, Stdout: "Docker version 24.0.0"}
+			}
+			return RunOutput{ExitCode: 1}
+		},
+	}
+
+	availability := detectAvailableEnvironments(runner)
+
+	if availability.DockerAvailable {
+		t.Error("expected DockerAvailable=false when docker daemon is not running")
+	}
+	if !availability.DockerInstalledButNotRunning {
+		t.Error("expected DockerInstalledButNotRunning=true when daemon is down but binary is present")
+	}
+	if availability.InstallHint == "" {
+		t.Error("expected a non-empty InstallHint when docker daemon is not running")
+	}
+}
+
+func TestDetectAvailableEnvironments_NeitherAvailable_SetsInstallHint(t *testing.T) {
+	runner := newMockCommandRunner(map[string]RunOutput{
+		// All commands fail — nothing is installed.
+	})
+
+	availability := detectAvailableEnvironments(runner)
+
+	if availability.DockerAvailable || availability.WSL2Available {
+		t.Error("expected both DockerAvailable and WSL2Available to be false")
+	}
+	if availability.InstallHint == "" {
+		t.Error("expected a non-empty InstallHint pointing to Docker Desktop download")
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// containsStringInSlice returns true if the target string appears anywhere in the slice.
+func containsStringInSlice(slice []string, target string) bool {
+	for _, element := range slice {
+		if element == target {
+			return true
+		}
+	}
+	return false
+}
+
+// callCountingMockRunner lets tests control responses with a callback function
+// instead of a static map, enabling stateful call-count-dependent responses.
+type callCountingMockRunner struct {
+	onRunCommand func(name string, args []string) RunOutput
+}
+
+func (c *callCountingMockRunner) RunCommand(_ context.Context, name string, args []string) (RunOutput, error) {
+	return c.onRunCommand(name, args), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -69,6 +69,11 @@ type Dependencies struct {
 	// AllowedTools restricts which built-in tools are registered.
 	// An empty/nil slice means all tools are exposed (the default).
 	AllowedTools []string
+
+	// EnvironmentCommandRunner overrides the default OS process runner used by the
+	// environment_detect and environment_run tools. Set this in tests to inject a
+	// mock without spawning real WSL or Docker processes. Nil means use the real runner.
+	EnvironmentCommandRunner CommandRunner
 }
 
 // NewServer creates a fully initialised MCP server.
@@ -220,6 +225,13 @@ func (srv *Server) registerBuiltInTools(deps Dependencies) {
 		allowed[name] = true
 	}
 
+	// Use the injected runner if provided (for tests), otherwise fall back to the
+	// real OS process runner that shells out to wsl.exe / docker / cmd.exe.
+	environmentRunner := deps.EnvironmentCommandRunner
+	if environmentRunner == nil {
+		environmentRunner = &realCommandRunner{}
+	}
+
 	candidates := []ToolHandler{
 		newTerminalSessionsTool(deps.TermHandler),
 		newTerminalExecuteTool(deps.TermHandler),
@@ -229,6 +241,8 @@ func (srv *Server) registerBuiltInTools(deps Dependencies) {
 		newFileListTool(deps.ProjectPath),
 		newTaskSubmitTool(srv.broker),
 		newWorkflowStatusTool(deps.ProjectPath, deps.WorkflowConfig),
+		newEnvironmentDetectTool(environmentRunner),
+		newEnvironmentRunTool(environmentRunner),
 	}
 
 	for _, tool := range candidates {

--- a/internal/mcp/tools_environment.go
+++ b/internal/mcp/tools_environment.go
@@ -1,0 +1,212 @@
+// tools_environment.go implements two Forge MCP environment tools:
+//
+//   - environment_detect — probes WSL2 and Docker availability on the host
+//   - environment_run    — executes a command in the best available Linux environment
+//
+// These tools give AI agents a first-class way to run Linux-required builds
+// (OpenNext, Turbopack, etc.) from a Windows host without resorting to
+// GitHub Actions workflows or manually configuring CI secrets.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ── environment_detect ────────────────────────────────────────────────────────
+
+// environmentDetectTool probes the host and reports which Linux execution
+// environments are available, so agents can choose a strategy before calling
+// environment_run.
+type environmentDetectTool struct {
+	runner CommandRunner
+}
+
+func newEnvironmentDetectTool(runner CommandRunner) ToolHandler {
+	return &environmentDetectTool{runner: runner}
+}
+
+// Definition returns the MCP tool descriptor for environment_detect.
+func (t *environmentDetectTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name: "environment_detect",
+		Description: "Reports which Linux execution environments (WSL2, Docker) are available on " +
+			"the host machine. Use this before calling environment_run to understand what strategies " +
+			"are available. Returns recommended strategy and any install hints if nothing is available.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {},
+			"required": []
+		}`),
+	}
+}
+
+// Execute probes for WSL2 and Docker, then returns availability as JSON.
+func (t *environmentDetectTool) Execute(_ map[string]any) (*CallToolResult, error) {
+	availability := detectAvailableEnvironments(t.runner)
+
+	output, marshalErr := json.MarshalIndent(availability, "", "  ")
+	if marshalErr != nil {
+		return errorContent("serialising availability result: " + marshalErr.Error()), nil
+	}
+
+	return textContent(string(output)), nil
+}
+
+// ── environment_run ───────────────────────────────────────────────────────────
+
+// environmentRunTool executes a shell command inside the requested Linux environment
+// and returns the exit code, stdout, stderr, and timing as structured JSON.
+type environmentRunTool struct {
+	runner CommandRunner
+}
+
+func newEnvironmentRunTool(runner CommandRunner) ToolHandler {
+	return &environmentRunTool{runner: runner}
+}
+
+// Definition returns the MCP tool descriptor for environment_run.
+func (t *environmentRunTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name: "environment_run",
+		Description: "Run a shell command in the specified environment (native, linux-wsl, linux-docker, or auto). " +
+			"Use 'auto' on Windows to automatically select WSL2 or Docker for Linux-compatible builds — this " +
+			"avoids Windows path issues with tools like Turbopack or OpenNext without needing GitHub Actions. " +
+			"Returns exit_code, stdout, stderr, environment_used, and duration_seconds.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"command": {
+					"type": "string",
+					"description": "The shell command to execute (e.g. 'npm run build')."
+				},
+				"environment": {
+					"type": "string",
+					"enum": ["auto", "native", "linux-wsl", "linux-docker"],
+					"description": "Execution environment. Use 'auto' to let Forge pick the best available Linux environment. Defaults to 'auto'."
+				},
+				"cwd": {
+					"type": "string",
+					"description": "Working directory for the command. Defaults to the current Forge project directory if omitted."
+				},
+				"image": {
+					"type": "string",
+					"description": "Docker image to use when environment is 'linux-docker'. Defaults to 'node:lts'."
+				},
+				"timeout_seconds": {
+					"type": "number",
+					"description": "Maximum seconds to wait for the command to finish (1–600). Default: 120."
+				}
+			},
+			"required": ["command"]
+		}`),
+	}
+}
+
+// Execute validates arguments, runs the command in the requested environment,
+// and returns the result as structured JSON text content.
+func (t *environmentRunTool) Execute(args map[string]any) (*CallToolResult, error) {
+	parsedArgs, parseErr := parseEnvironmentRunArgs(args)
+	if parseErr != nil {
+		return errorContent(parseErr.Error()), nil
+	}
+
+	timeout := time.Duration(parsedArgs.TimeoutSeconds) * time.Second
+	runCtx, cancelRun := context.WithTimeout(context.Background(), timeout)
+	defer cancelRun()
+
+	runResult, runErr := runInEnvironment(runCtx, t.runner, RunOptions{
+		Command:          parsedArgs.Command,
+		Environment:      parsedArgs.Environment,
+		WorkingDirectory: parsedArgs.WorkingDirectory,
+		DockerImage:      parsedArgs.DockerImage,
+	})
+	if runErr != nil {
+		return errorContent(fmt.Sprintf("environment run failed: %v", runErr)), nil
+	}
+
+	output, marshalErr := json.MarshalIndent(runResult, "", "  ")
+	if marshalErr != nil {
+		return errorContent("serialising run result: " + marshalErr.Error()), nil
+	}
+
+	return textContent(string(output)), nil
+}
+
+// ── Argument Parsing ──────────────────────────────────────────────────────────
+
+// environmentRunArgs holds the validated, normalised arguments for one environment_run call.
+type environmentRunArgs struct {
+	Command          string
+	Environment      string
+	WorkingDirectory string
+	DockerImage      string
+	TimeoutSeconds   int
+}
+
+// parseEnvironmentRunArgs extracts and validates the caller's arguments,
+// applying defaults for optional fields.
+func parseEnvironmentRunArgs(args map[string]any) (environmentRunArgs, error) {
+	parsed := environmentRunArgs{
+		Environment:    StrategyAuto,
+		DockerImage:    DefaultDockerImage,
+		TimeoutSeconds: defaultEnvironmentTimeoutSec,
+	}
+
+	// command is the only required field.
+	rawCommand, hasCommand := args["command"]
+	if !hasCommand {
+		return parsed, fmt.Errorf("command is required")
+	}
+	commandStr, isString := rawCommand.(string)
+	if !isString || commandStr == "" {
+		return parsed, fmt.Errorf("command must be a non-empty string")
+	}
+	parsed.Command = commandStr
+
+	if rawEnv, hasEnv := args["environment"]; hasEnv {
+		envStr, isEnvString := rawEnv.(string)
+		if !isEnvString {
+			return parsed, fmt.Errorf("environment must be a string")
+		}
+		if !isValidEnvironmentStrategy(envStr) {
+			return parsed, fmt.Errorf(
+				"environment must be one of: %s, %s, %s, %s",
+				StrategyAuto, StrategyNative, StrategyLinuxWSL, StrategyLinuxDocker,
+			)
+		}
+		parsed.Environment = envStr
+	}
+
+	if rawCwd, hasCwd := args["cwd"]; hasCwd {
+		if cwdStr, isCwdString := rawCwd.(string); isCwdString && cwdStr != "" {
+			parsed.WorkingDirectory = cwdStr
+		}
+	}
+
+	if rawImage, hasImage := args["image"]; hasImage {
+		if imageStr, isImageString := rawImage.(string); isImageString && imageStr != "" {
+			parsed.DockerImage = imageStr
+		}
+	}
+
+	if rawTimeout, hasTimeout := args["timeout_seconds"]; hasTimeout {
+		if floatVal, isFloat := rawTimeout.(float64); isFloat {
+			parsed.TimeoutSeconds = clampTimeout(int(floatVal))
+		}
+	}
+
+	return parsed, nil
+}
+
+// isValidEnvironmentStrategy returns true if the given strategy name is one
+// of the four recognised values accepted by environment_run.
+func isValidEnvironmentStrategy(strategy string) bool {
+	switch strategy {
+	case StrategyAuto, StrategyNative, StrategyLinuxWSL, StrategyLinuxDocker:
+		return true
+	}
+	return false
+}

--- a/internal/mcp/tools_environment_test.go
+++ b/internal/mcp/tools_environment_test.go
@@ -1,0 +1,320 @@
+// tools_environment_test.go tests the environment_detect and environment_run
+// MCP tools via the server's public ExecuteTool API.
+//
+// A mock CommandRunner is injected through Dependencies.EnvironmentCommandRunner
+// so no real WSL2, Docker, or shell processes are spawned during testing.
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mikejsmith1985/forge-terminal/internal/mcp"
+	"github.com/mikejsmith1985/forge-terminal/internal/workflow"
+)
+
+// ── Mock CommandRunner ────────────────────────────────────────────────────────
+
+// testCommandRunner is a simple mock that implements mcp.CommandRunner.
+// It returns canned responses keyed by executable name.
+type testCommandRunner struct {
+	responsesByExecutable map[string]mcp.RunOutput
+}
+
+func (m *testCommandRunner) RunCommand(_ context.Context, name string, _ []string) (mcp.RunOutput, error) {
+	if output, hasOutput := m.responsesByExecutable[name]; hasOutput {
+		return output, nil
+	}
+	return mcp.RunOutput{ExitCode: 1, Stderr: "mock: no response for " + name}, nil
+}
+
+// newDockerAvailableRunner returns a mock where docker is running and WSL2 is absent.
+// This represents the most common Windows dev machine setup.
+func newDockerAvailableRunner() *testCommandRunner {
+	return &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"docker": {ExitCode: 0, Stdout: "Server: Docker Engine"},
+		},
+	}
+}
+
+// newSuccessRunner returns a mock where any command reports success with sample output.
+func newSuccessRunner(executable string) *testCommandRunner {
+	return &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			executable: {ExitCode: 0, Stdout: "build complete"},
+		},
+	}
+}
+
+// buildEnvServer creates an MCP server with the given mock runner injected.
+func buildEnvServer(t *testing.T, runner mcp.CommandRunner) *mcp.Server {
+	t.Helper()
+	return mcp.NewServer("tok", mcp.Dependencies{
+		ProjectPath:             t.TempDir(),
+		WorkflowConfig:          workflow.WorkflowConfig{},
+		EnvironmentCommandRunner: runner,
+	})
+}
+
+// ── environment_detect tests ─────────────────────────────────────────────────
+
+func TestEnvironmentDetectTool_ReturnsValidJSON(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+	result := callTool(t, srv, "environment_detect", map[string]any{})
+
+	if result.IsError {
+		t.Fatalf("expected no error from environment_detect, got: %v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least one content item in environment_detect response")
+	}
+
+	var availability map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &availability); err != nil {
+		t.Fatalf("environment_detect response is not valid JSON: %v — got: %s", err, result.Content[0].Text)
+	}
+}
+
+func TestEnvironmentDetectTool_ReportsDockerAvailableWhenDaemonIsRunning(t *testing.T) {
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"docker": {ExitCode: 0, Stdout: "Server: Docker Engine"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_detect", map[string]any{})
+
+	var availability map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &availability); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if availability["docker_available"] != true {
+		t.Errorf("expected docker_available=true when docker daemon responds, got: %v", availability["docker_available"])
+	}
+}
+
+func TestEnvironmentDetectTool_ReportsDockerNotAvailableWhenDaemonIsDown(t *testing.T) {
+	// All docker calls fail — simulates Docker not installed at all.
+	runner := &testCommandRunner{responsesByExecutable: map[string]mcp.RunOutput{}}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_detect", map[string]any{})
+
+	var availability map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &availability); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if availability["docker_available"] == true {
+		t.Error("expected docker_available=false when docker commands fail")
+	}
+}
+
+func TestEnvironmentDetectTool_ReturnsRecommendedField(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+	result := callTool(t, srv, "environment_detect", map[string]any{})
+
+	var availability map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &availability); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	recommended, hasRecommended := availability["recommended"].(string)
+	if !hasRecommended || recommended == "" {
+		t.Errorf("expected a non-empty 'recommended' field, got: %v", availability["recommended"])
+	}
+}
+
+// ── environment_run tests — argument validation ────────────────────────────────
+
+func TestEnvironmentRunTool_MissingCommand_ReturnsError(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"environment": "native",
+	})
+
+	if !result.IsError {
+		t.Error("expected IsError=true when 'command' is missing")
+	}
+}
+
+func TestEnvironmentRunTool_EmptyCommand_ReturnsError(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command": "",
+	})
+
+	if !result.IsError {
+		t.Error("expected IsError=true when 'command' is an empty string")
+	}
+}
+
+func TestEnvironmentRunTool_InvalidEnvironmentStrategy_ReturnsError(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "npm run build",
+		"environment": "invalid-strategy",
+	})
+
+	if !result.IsError {
+		t.Error("expected IsError=true for an unrecognised environment strategy")
+	}
+}
+
+// ── environment_run tests — happy path ────────────────────────────────────────
+
+func TestEnvironmentRunTool_NativeStrategy_ReturnsJSONWithExitCode(t *testing.T) {
+	// Use "cmd" on Windows or "bash" on Linux/macOS as the expected executable.
+	// The mock responds to both so this test is cross-platform.
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"cmd":  {ExitCode: 0, Stdout: "hello from native"},
+			"bash": {ExitCode: 0, Stdout: "hello from native"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "echo hello",
+		"environment": "native",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected no error for native strategy, got: %v", result.Content)
+	}
+
+	var runResult map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &runResult); err != nil {
+		t.Fatalf("environment_run response is not valid JSON: %v — got: %s", err, result.Content[0].Text)
+	}
+
+	if _, hasExitCode := runResult["exit_code"]; !hasExitCode {
+		t.Error("expected 'exit_code' field in environment_run result JSON")
+	}
+	if _, hasEnvUsed := runResult["environment_used"]; !hasEnvUsed {
+		t.Error("expected 'environment_used' field in environment_run result JSON")
+	}
+}
+
+func TestEnvironmentRunTool_DockerStrategy_ReturnsEnvironmentUsedField(t *testing.T) {
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"docker": {ExitCode: 0, Stdout: "build successful"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "npm run build",
+		"environment": "linux-docker",
+		"cwd":         t.TempDir(),
+	})
+
+	if result.IsError {
+		t.Fatalf("expected no error for linux-docker strategy, got: %v", result.Content)
+	}
+
+	var runResult map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &runResult); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if runResult["environment_used"] != "linux-docker" {
+		t.Errorf("expected environment_used='linux-docker', got: %v", runResult["environment_used"])
+	}
+}
+
+func TestEnvironmentRunTool_WSLStrategy_ReturnsEnvironmentUsedField(t *testing.T) {
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"wsl.exe": {ExitCode: 0, Stdout: "build successful"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "npm run build",
+		"environment": "linux-wsl",
+		"cwd":         `C:\Projects\app`,
+	})
+
+	if result.IsError {
+		t.Fatalf("expected no error for linux-wsl strategy, got: %v", result.Content)
+	}
+
+	var runResult map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &runResult); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if runResult["environment_used"] != "linux-wsl" {
+		t.Errorf("expected environment_used='linux-wsl', got: %v", runResult["environment_used"])
+	}
+}
+
+func TestEnvironmentRunTool_AutoStrategy_UsesDockerWhenOnlyDockerAvailable(t *testing.T) {
+	// Docker responds; WSL does not — auto should pick linux-docker.
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"docker": {ExitCode: 0, Stdout: "build output"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "npm run build",
+		"environment": "auto",
+		"cwd":         t.TempDir(),
+	})
+
+	if result.IsError {
+		t.Fatalf("expected no error for auto strategy with Docker available, got: %v", result.Content)
+	}
+
+	var runResult map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &runResult); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if runResult["environment_used"] != "linux-docker" {
+		t.Errorf("expected auto to select 'linux-docker', got: %v", runResult["environment_used"])
+	}
+}
+
+func TestEnvironmentRunTool_NonZeroExitCode_IsNotAnError(t *testing.T) {
+	// A command that exits non-zero is a build failure, not a tool failure.
+	// IsError should be false; the exit_code should reflect the actual code.
+	runner := &testCommandRunner{
+		responsesByExecutable: map[string]mcp.RunOutput{
+			"cmd":  {ExitCode: 1, Stderr: "build failed"},
+			"bash": {ExitCode: 1, Stderr: "build failed"},
+		},
+	}
+	srv := buildEnvServer(t, runner)
+	result := callTool(t, srv, "environment_run", map[string]any{
+		"command":     "npm run build",
+		"environment": "native",
+	})
+
+	// The tool itself should succeed (IsError=false) — it's the command that failed.
+	if result.IsError {
+		t.Error("expected IsError=false for a command with non-zero exit code — that's a build failure, not a tool failure")
+	}
+
+	var runResult map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &runResult); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if runResult["exit_code"] == float64(0) {
+		t.Error("expected exit_code to reflect the non-zero exit from the command")
+	}
+}
+
+func TestEnvironmentRunTool_ToolsListIncludesNewTools(t *testing.T) {
+	srv := buildEnvServer(t, newDockerAvailableRunner())
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
+	result := callTool(t, srv, "environment_detect", map[string]any{})
+
+	// If environment_detect is callable it must be registered — this also
+	// verifies environment_run implicitly since they're registered together.
+	if result == nil {
+		t.Fatal("expected environment_detect to be registered in the tool list")
+	}
+	_ = body
+}


### PR DESCRIPTION
Adds two MCP tools so AI agents can run commands in Linux environments (WSL2/Docker) directly from Windows instead of falling back to GitHub Actions. See CHANGELOG.md for details.