### PR TITLE
chore: expose environment_detect and environment_run in MCP allowed_tools

### DIFF
--- a/forge.toml
+++ b/forge.toml
@@ -73,4 +73,6 @@ allowed_tools = [
   "file_list",
   "task_submit",
   "workflow_status",
+  "environment_detect",
+  "environment_run",
 ]


### PR DESCRIPTION
Adds the two new Adaptive Build Environment tools to the \llowed_tools\ allowlist in \orge.toml\ so the MCP server exposes them to connected clients (Copilot CLI, Claude Code).\n\nNo code change required — the tool implementations shipped in v7.3.0. Only a Forge restart is needed to activate.