### PR TITLE
feat: hot-reload forge.toml allowed_tools without restarting Forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP config hot-reload** — Forge now watches `forge.toml` for changes every 5 seconds and automatically applies a new `allowed_tools` list without restarting. A `POST /api/mcp/reload` endpoint is also available for instant manual reload. Parse failures are logged and safely ignored — the previous tool list is preserved to prevent accidental permission changes.
+
+### Fixed
+- **Task status endpoint auth** — `GET /api/mcp/tasks/{id}` now requires the bearer token (previously had no auth check despite the misleading comment).
+
 ## [7.3.0] - 2026-04-21
 
 ---

--- a/cmd/forge/handlers_mcp.go
+++ b/cmd/forge/handlers_mcp.go
@@ -10,11 +10,13 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mikejsmith1985/forge-terminal/internal/mcp"
@@ -37,29 +39,40 @@ type forgeTOMLPartial struct {
 	MCP mcpTOMLConfig `toml:"mcp"`
 }
 
-// loadMCPConfig reads forge.toml from the project root and returns the [mcp]
-// section. If the file is absent or the section is missing, safe defaults are
-// returned (enabled=true, all tools allowed).
-func loadMCPConfig() mcpTOMLConfig {
+// defaultMCPConfig returns safe startup defaults: MCP enabled, all tools exposed.
+func defaultMCPConfig() mcpTOMLConfig {
 	trueVal := true
-	defaults := mcpTOMLConfig{Enabled: &trueVal, AllowedTools: nil}
+	return mcpTOMLConfig{Enabled: &trueVal, AllowedTools: nil}
+}
 
-	// Prefer forge.toml in the current working directory (project root).
-	configPath := "forge.toml"
+// loadMCPConfigFromPath reads the [mcp] section from the TOML file at configPath.
+// Unlike loadMCPConfig, it returns an error so callers can distinguish a real
+// parse failure from a missing section. The caller is responsible for fallback logic.
+func loadMCPConfigFromPath(configPath string) (mcpTOMLConfig, error) {
 	if _, err := os.Stat(configPath); err != nil {
-		return defaults
+		return mcpTOMLConfig{}, fmt.Errorf("forge.toml not found at %s: %w", configPath, err)
 	}
 
 	var partial forgeTOMLPartial
 	if _, err := toml.DecodeFile(configPath, &partial); err != nil {
-		log.Printf("[MCP] Could not parse forge.toml [mcp] section: %v — using defaults", err)
-		return defaults
+		return mcpTOMLConfig{}, fmt.Errorf("parsing forge.toml: %w", err)
 	}
 
 	cfg := partial.MCP
-	// If the [mcp] section was absent, Enabled is nil — default to enabled.
 	if cfg.Enabled == nil {
+		trueVal := true
 		cfg.Enabled = &trueVal
+	}
+	return cfg, nil
+}
+
+// loadMCPConfig reads forge.toml from the current directory, returning safe defaults
+// on any error. This is the startup path; errors are logged but not fatal.
+func loadMCPConfig() mcpTOMLConfig {
+	cfg, err := loadMCPConfigFromPath("forge.toml")
+	if err != nil {
+		log.Printf("[MCP] Could not parse forge.toml [mcp] section: %v — using defaults", err)
+		return defaultMCPConfig()
 	}
 	return cfg
 }
@@ -75,6 +88,11 @@ func mcpEnabled(cfg mcpTOMLConfig) bool {
 // Initialised by initMCPServer() at startup and accessed from the route handlers.
 var mcpServer *mcp.Server
 
+// mcpConfigAbsPath is the absolute path to forge.toml, resolved once at startup.
+// Both the config watcher and the /api/mcp/reload handler use this path so they
+// always read the same file regardless of any later cwd changes.
+var mcpConfigAbsPath string
+
 // initMCPServer creates the MCP server and loads (or auto-generates) the bearer token.
 // It is called once from main() before the HTTP listener starts.
 func initMCPServer() {
@@ -83,6 +101,14 @@ func initMCPServer() {
 		log.Printf("[MCP] Disabled via forge.toml — MCP endpoint will not be active")
 		return
 	}
+
+	// Resolve the absolute config path once so both the watcher and the reload
+	// endpoint always read the same file, even if the process cwd changes later.
+	absPath, err := filepath.Abs("forge.toml")
+	if err != nil {
+		absPath = "forge.toml"
+	}
+	mcpConfigAbsPath = absPath
 
 	authToken, err := mcp.LoadOrCreateToken()
 	if err != nil {
@@ -103,6 +129,10 @@ func initMCPServer() {
 
 	mcpServer = mcp.NewServer(authToken, deps)
 	log.Printf("[MCP] Server ready — endpoint: /api/mcp | token: ~/.forge/mcp-token")
+
+	// Start watching forge.toml for changes. Tool list updates take effect
+	// automatically without restarting Forge.
+	go startForgeConfigWatcher(mcpConfigAbsPath)
 }
 
 // handleMCP is the unified HTTP handler for POST /api/mcp and GET /api/mcp.
@@ -135,9 +165,14 @@ func handleMCPTaskStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Auth check — same token, same standard.
 	if mcpServer == nil {
 		http.Error(w, `{"error":"MCP server not initialised"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	// Require the same bearer token as /api/mcp — task results are sensitive.
+	if !mcpServer.ValidateHTTPRequest(r) {
+		http.Error(w, `{"error":"invalid or missing bearer token"}`, http.StatusUnauthorized)
 		return
 	}
 
@@ -157,6 +192,105 @@ func handleMCPTaskStatus(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(task)
+}
+
+// handleMCPReload handles POST /api/mcp/reload — re-reads the [mcp] section of
+// forge.toml and applies a fresh allowed_tools filter without restarting Forge.
+// This endpoint requires the same bearer token as /api/mcp.
+func handleMCPReload(w http.ResponseWriter, r *http.Request) {
+	applyCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "only POST is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if mcpServer == nil {
+		http.Error(w, `{"error":"MCP server not initialised"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	if !mcpServer.ValidateHTTPRequest(r) {
+		http.Error(w, `{"error":"invalid or missing bearer token"}`, http.StatusUnauthorized)
+		return
+	}
+
+	cfg, err := loadMCPConfigFromPath(mcpConfigAbsPath)
+	if err != nil {
+		// Return the error so the caller knows the file is unreadable, but do
+		// NOT apply defaults — that could silently widen tool permissions.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(map[string]string{"error": "could not parse forge.toml: " + err.Error()})
+		return
+	}
+
+	mcpServer.ReloadAllowedTools(cfg.AllowedTools)
+	log.Printf("[MCP] Tool list reloaded via /api/mcp/reload")
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(map[string]any{
+		"status":        "reloaded",
+		"allowed_tools": cfg.AllowedTools,
+	})
+}
+
+// ── Config Watcher ────────────────────────────────────────────────────────────
+
+// configWatchIntervalSeconds is the polling interval for forge.toml change detection.
+// Five seconds balances responsiveness against unnecessary stat() syscalls.
+const configWatchIntervalSeconds = 5
+
+// startForgeConfigWatcher polls configPath every configWatchIntervalSeconds.
+// When forge.toml's modification time changes, it reloads allowed_tools without
+// restarting Forge. Parse failures are logged but never applied — the previous
+// tool list is preserved to avoid accidentally widening permissions on a bad save.
+func startForgeConfigWatcher(configPath string) {
+	ticker := time.NewTicker(configWatchIntervalSeconds * time.Second)
+	defer ticker.Stop()
+
+	// Seed the last-known modification time so the first tick is a no-op.
+	lastModTime := resolveFileModTime(configPath)
+
+	for range ticker.C {
+		if mcpServer == nil {
+			continue
+		}
+
+		currentModTime := resolveFileModTime(configPath)
+		if !currentModTime.After(lastModTime) {
+			continue // nothing changed
+		}
+		lastModTime = currentModTime
+
+		cfg, err := loadMCPConfigFromPath(configPath)
+		if err != nil {
+			// Keep the previous allowed_tools — a broken save should not open or
+			// close tool access until the file is valid again.
+			log.Printf("[MCP] Config watcher: could not parse %s — keeping previous allowed_tools: %v", configPath, err)
+			continue
+		}
+
+		mcpServer.ReloadAllowedTools(cfg.AllowedTools)
+		log.Printf("[MCP] Config watcher: reloaded allowed_tools from %s", configPath)
+	}
+}
+
+// resolveFileModTime returns the modification time of a file, or the zero time
+// if the file cannot be stat'd (e.g. during an editor's atomic write cycle).
+func resolveFileModTime(filePath string) time.Time {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/cmd/forge/main.go
+++ b/cmd/forge/main.go
@@ -537,6 +537,7 @@ func main() {
 	// Must be initialised AFTER termHandler is set (line ~282 above).
 	initMCPServer()
 	http.HandleFunc("/api/mcp", handleMCP)
+	http.HandleFunc("/api/mcp/reload", handleMCPReload)
 	http.HandleFunc("/api/mcp/tasks/", handleMCPTaskStatus)
 
 	// ── License routes (always available — bypass LicenseMiddleware) ──────

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 
 	"github.com/mikejsmith1985/forge-terminal/internal/terminal"
 	"github.com/mikejsmith1985/forge-terminal/internal/workflow"
@@ -48,8 +49,12 @@ type ToolHandler interface {
 
 // Server is the Forge Terminal MCP server. It holds the tool registry,
 // auth token, and the dependencies each tool needs to do its work.
+// The tool registry is hot-reloadable: call ReloadAllowedTools to apply a
+// new forge.toml allowed_tools list without restarting the process.
 type Server struct {
 	authToken string
+	deps      Dependencies  // retained so ReloadAllowedTools can rebuild handlers
+	toolsMu   sync.RWMutex // guards the tools map for concurrent reload safety
 	tools     map[string]ToolHandler
 	broker    *TaskBroker
 }
@@ -83,12 +88,36 @@ func NewServer(authToken string, deps Dependencies) *Server {
 
 	srv := &Server{
 		authToken: authToken,
+		deps:      deps,
 		tools:     make(map[string]ToolHandler),
 		broker:    broker,
 	}
 
-	srv.registerBuiltInTools(deps)
+	srv.tools = srv.buildToolRegistry(deps.AllowedTools)
 	return srv
+}
+
+// ReloadAllowedTools applies a new allowed_tools list from forge.toml without
+// restarting Forge. Existing in-flight tool calls complete normally — the lock
+// is held only long enough to swap the map pointer. Passing an empty slice
+// restores the default behaviour (all built-in tools are exposed).
+func (srv *Server) ReloadAllowedTools(allowedTools []string) {
+	freshTools := srv.buildToolRegistry(allowedTools)
+
+	srv.toolsMu.Lock()
+	previousTools := srv.tools
+	srv.tools = freshTools
+	srv.toolsMu.Unlock()
+
+	// Log which tools were added or removed so the operator can verify the reload.
+	logToolDiff(previousTools, freshTools)
+}
+
+// ValidateHTTPRequest returns true when the request carries the correct bearer
+// token. Used by handlers that live outside the MCP server's HandleHTTP path
+// (e.g. /api/mcp/tasks, /api/mcp/reload) but need the same auth guarantee.
+func (srv *Server) ValidateHTTPRequest(r *http.Request) bool {
+	return ValidateRequestToken(r, srv.authToken)
 }
 
 // Broker returns the task broker so the Forge agent loop can consume submitted tasks.
@@ -99,7 +128,10 @@ func (srv *Server) Broker() *TaskBroker {
 // ExecuteTool calls a named tool directly, bypassing HTTP and auth.
 // Intended for unit testing only — not exposed over HTTP.
 func (srv *Server) ExecuteTool(name string, args map[string]any) (*CallToolResult, error) {
+	srv.toolsMu.RLock()
 	handler, found := srv.tools[name]
+	srv.toolsMu.RUnlock()
+
 	if !found {
 		return nil, fmt.Errorf("tool %q not registered", name)
 	}
@@ -160,12 +192,13 @@ func (srv *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 // ── RPC Method Handlers ──────────────────────────────────────────────────────
 
 // handleInitialize responds to the MCP handshake with server capabilities.
+// listChanged is true because forge.toml hot-reload can change the tool set at runtime.
 func (srv *Server) handleInitialize(w http.ResponseWriter, req *JSONRPCRequest) {
 	result := InitializeResult{
 		ProtocolVersion: mcpProtocolVersion,
 		ServerInfo:      MCPServerInfo{Name: serverName},
 		Capabilities: MCPCapabilities{
-			Tools: map[string]any{"listChanged": false},
+			Tools: map[string]any{"listChanged": true},
 		},
 	}
 	encodeJSON(w, JSONRPCResponse{
@@ -185,6 +218,8 @@ func (srv *Server) handleToolsList(w http.ResponseWriter, req *JSONRPCRequest) {
 }
 
 // handleToolsCall dispatches a tools/call request to the matching ToolHandler.
+// The tools map lock is held only for the initial lookup, not during Execute,
+// so long-running tools (environment_run, terminal ops) do not block reloads.
 func (srv *Server) handleToolsCall(w http.ResponseWriter, req *JSONRPCRequest) {
 	callReq, err := decodeCallRequest(req.Params)
 	if err != nil {
@@ -193,7 +228,11 @@ func (srv *Server) handleToolsCall(w http.ResponseWriter, req *JSONRPCRequest) {
 		return
 	}
 
+	// Snapshot the handler under a short read lock, then release before Execute.
+	srv.toolsMu.RLock()
 	handler, found := srv.tools[callReq.Name]
+	srv.toolsMu.RUnlock()
+
 	if !found {
 		srv.writeRPCError(w, req.ID, ErrorCodeMethodNotFound,
 			fmt.Sprintf("unknown tool %q", callReq.Name))
@@ -215,55 +254,72 @@ func (srv *Server) handleToolsCall(w http.ResponseWriter, req *JSONRPCRequest) {
 
 // ── Registry ─────────────────────────────────────────────────────────────────
 
-// registerBuiltInTools adds all Forge tools to the registry.
-// If deps.AllowedTools is non-empty, only the named tools are registered.
-// This is called once inside NewServer.
-func (srv *Server) registerBuiltInTools(deps Dependencies) {
-	allowed := make(map[string]bool, len(deps.AllowedTools))
-	filterActive := len(deps.AllowedTools) > 0
-	for _, name := range deps.AllowedTools {
-		allowed[name] = true
+// buildToolRegistry constructs a fresh tools map filtered by allowedTools.
+// An empty or nil allowedTools slice means all built-in tools are exposed.
+// This is called both at startup (inside NewServer) and on each hot-reload.
+func (srv *Server) buildToolRegistry(allowedTools []string) map[string]ToolHandler {
+	// Build the allowed-name set for O(1) lookup.
+	isFilterActive := len(allowedTools) > 0
+	allowedByName := make(map[string]bool, len(allowedTools))
+	for _, toolName := range allowedTools {
+		allowedByName[toolName] = true
 	}
 
-	// Use the injected runner if provided (for tests), otherwise fall back to the
-	// real OS process runner that shells out to wsl.exe / docker / cmd.exe.
-	environmentRunner := deps.EnvironmentCommandRunner
+	// Use the injected runner if provided (for tests), otherwise use the real
+	// OS process runner that shells out to wsl.exe / docker / cmd.exe.
+	environmentRunner := srv.deps.EnvironmentCommandRunner
 	if environmentRunner == nil {
 		environmentRunner = &realCommandRunner{}
 	}
 
 	candidates := []ToolHandler{
-		newTerminalSessionsTool(deps.TermHandler),
-		newTerminalExecuteTool(deps.TermHandler),
-		newTerminalReadTool(deps.TermHandler),
-		newFileReadTool(deps.ProjectPath),
-		newFileWriteTool(deps.ProjectPath),
-		newFileListTool(deps.ProjectPath),
+		newTerminalSessionsTool(srv.deps.TermHandler),
+		newTerminalExecuteTool(srv.deps.TermHandler),
+		newTerminalReadTool(srv.deps.TermHandler),
+		newFileReadTool(srv.deps.ProjectPath),
+		newFileWriteTool(srv.deps.ProjectPath),
+		newFileListTool(srv.deps.ProjectPath),
 		newTaskSubmitTool(srv.broker),
-		newWorkflowStatusTool(deps.ProjectPath, deps.WorkflowConfig),
+		newWorkflowStatusTool(srv.deps.ProjectPath, srv.deps.WorkflowConfig),
 		newEnvironmentDetectTool(environmentRunner),
 		newEnvironmentRunTool(environmentRunner),
 	}
 
+	registry := make(map[string]ToolHandler, len(candidates))
 	for _, tool := range candidates {
-		if filterActive && !allowed[tool.Definition().Name] {
-			log.Printf("[MCP] Tool %q disabled by forge.toml allowed_tools", tool.Definition().Name)
+		toolName := tool.Definition().Name
+		if isFilterActive && !allowedByName[toolName] {
+			log.Printf("[MCP] Tool %q disabled by forge.toml allowed_tools", toolName)
 			continue
 		}
-		srv.register(tool)
+		registry[toolName] = tool
 	}
+	return registry
 }
 
-// register adds a single ToolHandler to the registry under its declared name.
-func (srv *Server) register(tool ToolHandler) {
-	name := tool.Definition().Name
-	srv.tools[name] = tool
+// logToolDiff emits a log line for each tool added or removed between reloads,
+// so operators can confirm that hot-reload applied the expected changes.
+func logToolDiff(previousTools, freshTools map[string]ToolHandler) {
+	for toolName := range freshTools {
+		if _, wasPresent := previousTools[toolName]; !wasPresent {
+			log.Printf("[MCP] Hot-reload: tool %q is now enabled", toolName)
+		}
+	}
+	for toolName := range previousTools {
+		if _, isPresent := freshTools[toolName]; !isPresent {
+			log.Printf("[MCP] Hot-reload: tool %q is now disabled", toolName)
+		}
+	}
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 // buildToolList constructs a ListToolsResult from the current registry.
+// The read lock ensures this is safe to call concurrently with ReloadAllowedTools.
 func (srv *Server) buildToolList() ListToolsResult {
+	srv.toolsMu.RLock()
+	defer srv.toolsMu.RUnlock()
+
 	definitions := make([]ToolDefinition, 0, len(srv.tools))
 	for _, handler := range srv.tools {
 		definitions = append(definitions, handler.Definition())

--- a/internal/mcp/server_reload_test.go
+++ b/internal/mcp/server_reload_test.go
@@ -1,0 +1,164 @@
+// server_reload_test.go verifies the hot-reload behaviour of the MCP server's
+// allowed_tools filter. Tests confirm that ReloadAllowedTools takes effect
+// immediately for new calls and that the server remains race-free under load.
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// buildReloadTestServer creates a server whose tool registry can be rebuilt
+// without network or filesystem access. The injected mock runner satisfies
+// the environment tools so all built-in tools are constructable in tests.
+func buildReloadTestServer(allowedTools []string) *Server {
+	deps := Dependencies{
+		AllowedTools:             allowedTools,
+		EnvironmentCommandRunner: &mockCommandRunner{},
+	}
+	return NewServer("test-token", deps)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+// TestReloadAllowedTools_MakesNewToolAvailable verifies that a tool blocked by
+// the initial filter becomes callable after ReloadAllowedTools adds it.
+func TestReloadAllowedTools_MakesNewToolAvailable(t *testing.T) {
+	// Start with only file_list allowed — terminal tools are blocked.
+	srv := buildReloadTestServer([]string{"file_list"})
+
+	_, initialErr := srv.ExecuteTool("terminal_sessions", nil)
+	if initialErr == nil {
+		t.Fatal("expected terminal_sessions to be blocked before reload, but it succeeded")
+	}
+
+	// Reload with terminal_sessions also allowed.
+	srv.ReloadAllowedTools([]string{"file_list", "terminal_sessions"})
+
+	_, reloadedErr := srv.ExecuteTool("terminal_sessions", nil)
+	if reloadedErr != nil {
+		t.Fatalf("expected terminal_sessions to be available after reload, got error: %v", reloadedErr)
+	}
+}
+
+// TestReloadAllowedTools_RemovesDisabledTool verifies that a tool accessible
+// before reload becomes blocked after it is removed from the allowed list.
+func TestReloadAllowedTools_RemovesDisabledTool(t *testing.T) {
+	// Start with all tools exposed (empty allowed list = no filter).
+	srv := buildReloadTestServer(nil)
+
+	_, initialErr := srv.ExecuteTool("terminal_sessions", nil)
+	if initialErr != nil {
+		t.Fatalf("expected terminal_sessions to be available at start, got error: %v", initialErr)
+	}
+
+	// Reload with a list that excludes terminal_sessions.
+	srv.ReloadAllowedTools([]string{"file_list"})
+
+	_, afterReloadErr := srv.ExecuteTool("terminal_sessions", nil)
+	if afterReloadErr == nil {
+		t.Fatal("expected terminal_sessions to be blocked after reload, but it succeeded")
+	}
+}
+
+// TestReloadAllowedTools_EmptyListAllowsAllTools verifies that passing an empty
+// slice to ReloadAllowedTools restores the "all tools exposed" default — the same
+// semantics used at startup when allowed_tools is absent from forge.toml.
+func TestReloadAllowedTools_EmptyListAllowsAllTools(t *testing.T) {
+	// Start with a restricted list.
+	srv := buildReloadTestServer([]string{"file_list"})
+
+	_, restrictedErr := srv.ExecuteTool("terminal_sessions", nil)
+	if restrictedErr == nil {
+		t.Fatal("expected terminal_sessions to be blocked by initial filter")
+	}
+
+	// Reload with an empty list — should expose all built-in tools.
+	srv.ReloadAllowedTools([]string{})
+
+	_, openErr := srv.ExecuteTool("terminal_sessions", nil)
+	if openErr != nil {
+		t.Fatalf("expected terminal_sessions to be available after clearing the filter: %v", openErr)
+	}
+}
+
+// TestReloadAllowedTools_ParseFailureKeepsLastGoodConfig demonstrates the intent
+// of the fail-safe rule: the reload helper in handlers_mcp.go must not call
+// ReloadAllowedTools when loadMCPConfigFromPath returns an error. This test
+// verifies that a reload with a known-good list is stable and that a subsequent
+// reload with the same list produces the same result (idempotent).
+func TestReloadAllowedTools_IsIdempotent(t *testing.T) {
+	srv := buildReloadTestServer([]string{"file_list"})
+
+	// Apply the same reload twice — the second call must not change the tool set.
+	srv.ReloadAllowedTools([]string{"file_list"})
+	srv.ReloadAllowedTools([]string{"file_list"})
+
+	_, err := srv.ExecuteTool("file_list", map[string]any{"path": "."})
+	if err != nil {
+		t.Fatalf("file_list should remain available after idempotent reload: %v", err)
+	}
+
+	_, blockedErr := srv.ExecuteTool("terminal_sessions", nil)
+	if blockedErr == nil {
+		t.Fatal("terminal_sessions should remain blocked after idempotent reload")
+	}
+}
+
+// TestReloadAllowedTools_ConcurrentSafety exercises ReloadAllowedTools alongside
+// concurrent ExecuteTool calls to confirm there are no data races.
+// Run with: go test -race ./internal/mcp/
+func TestReloadAllowedTools_ConcurrentSafety(t *testing.T) {
+	srv := buildReloadTestServer(nil) // start with all tools allowed
+
+	var waitGroup sync.WaitGroup
+
+	// Spawn goroutines that concurrently reload and call tools.
+	for goroutineIndex := 0; goroutineIndex < 20; goroutineIndex++ {
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+
+			if index%2 == 0 {
+				// Even goroutines reload between two lists.
+				if index%4 == 0 {
+					srv.ReloadAllowedTools([]string{"file_list"})
+				} else {
+					srv.ReloadAllowedTools(nil)
+				}
+			} else {
+				// Odd goroutines execute a tool call — the result may be a
+				// "not registered" error if a reload disabled it, which is fine.
+				srv.ExecuteTool("terminal_sessions", nil) //nolint:errcheck
+			}
+		}(goroutineIndex)
+	}
+
+	waitGroup.Wait()
+	// If the race detector found a problem it will have already panicked or
+	// caused test failure. Reaching here means no data race was detected.
+}
+
+// TestReloadAllowedTools_BuildToolListConsistency verifies that buildToolList
+// (used by tools/list RPC) reflects the state set by the most recent reload.
+func TestReloadAllowedTools_BuildToolListConsistency(t *testing.T) {
+	srv := buildReloadTestServer([]string{"file_list"})
+
+	// Only file_list should be in the initial list.
+	initialList := srv.buildToolList()
+	if len(initialList.Tools) != 1 {
+		t.Fatalf("expected 1 tool after filtered init, got %d", len(initialList.Tools))
+	}
+	if initialList.Tools[0].Name != "file_list" {
+		t.Fatalf("expected file_list to be the sole tool, got %q", initialList.Tools[0].Name)
+	}
+
+	// After clearing the filter all built-in tools should appear.
+	srv.ReloadAllowedTools(nil)
+	fullList := srv.buildToolList()
+	if len(fullList.Tools) < 2 {
+		t.Fatalf("expected multiple tools after clearing filter, got %d", len(fullList.Tools))
+	}
+}


### PR DESCRIPTION
## Summary

Adds live hot-reload of allowed_tools from forge.toml. Previously any change to the MCP tool filter required a full Forge restart.

## What Changed

### internal/mcp/server.go
- toolsMu sync.RWMutex protects the tool registry
- deps Dependencies stored on server so handlers can be rebuilt on reload
- ReloadAllowedTools([]string) — public method; write-locks, rebuilds map, logs diff
- ValidateHTTPRequest(r) — extracted for handlers outside HandleHTTP
- Lock scope narrowed: map lookup only, not during Execute()
- listChanged: true in initialize so clients re-fetch tools/list

### cmd/forge/handlers_mcp.go
- loadMCPConfigFromPath (returns error) + loadMCPConfig (startup wrapper)
- startForgeConfigWatcher — polls every 5s via os.Stat ModTime; fail-safe on parse errors
- handleMCPReload — POST /api/mcp/reload, bearer-token gated
- Fixed: handleMCPTaskStatus now enforces bearer token (was missing)

### cmd/forge/main.go
- Registered /api/mcp/reload route

### internal/mcp/server_reload_test.go (new)
- 6 tests: enable on reload, disable, empty = all tools, idempotent, concurrent safety (20 goroutines), buildToolList consistency

## Security
- Fail-safe: parse errors log and preserve last-good allowed_tools — bad save cannot widen permissions
- Auth: reload endpoint requires same bearer token as all MCP routes
- No permission widening: defaultMCPConfig only applied at startup

## Test Results
All 6 new reload tests pass. Build compiles clean.