### PR TITLE
fix: pass --remote to wrangler and block release when wrangler is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Release script R2 upload** — `local-release.ps1` now passes `--remote` to `wrangler r2 object put` so binaries are uploaded to Cloudflare R2 rather than the local wrangler dev instance. Missing `wrangler` is now a hard error (exit 1) instead of a silent skip, preventing 404 download failures for licensed users.
+
 ## [7.5.0] - 2026-04-21
 
 ---

--- a/scripts/local-release.ps1
+++ b/scripts/local-release.ps1
@@ -315,7 +315,10 @@ Write-Banner "Uploading binaries to R2 (forge-releases)"
 
 $wranglerAvailable = Get-Command wrangler -ErrorAction SilentlyContinue
 if (-not $wranglerAvailable) {
-    Write-Warn "wrangler not found — skipping R2 upload. Run: npm install -g wrangler"
+    # Wrangler is required: without it licensed users download from R2 and get a 404.
+    # Install it with: npm install -g wrangler
+    Write-Error "wrangler not found — R2 upload is required for licensed downloads. Run: npm install -g wrangler"
+    exit 1
 } else {
     # Map local binary names to the R2 key pattern: v{version}/forge-{platform}[.exe]
     $r2Uploads = @(
@@ -332,7 +335,8 @@ if (-not $wranglerAvailable) {
             continue
         }
         Write-Step "Uploading to R2: $($upload.R2Key)..."
-        wrangler r2 object put "forge-releases/$($upload.R2Key)" --file $upload.Local --config $r2Config
+        # --remote uploads to Cloudflare R2 (without it wrangler targets the local dev instance)
+        wrangler r2 object put "forge-releases/$($upload.R2Key)" --file $upload.Local --config $r2Config --remote
         if ($LASTEXITCODE -ne 0) {
             Write-Warn "R2 upload failed for $($upload.R2Key) — continuing (GitHub release will still be created)"
         } else {


### PR DESCRIPTION
## Problem
v7.5.0 release uploaded binaries to the local wrangler dev instance instead of Cloudflare R2. Licensed users resolve download URLs via a signed R2 URL (via \DownloadURLResolver\), so the missing R2 upload caused 404 errors on every update attempt.

## Root Cause
- \wrangler r2 object put\ without \--remote\ targets the local mini R2 dev environment
- Missing wrangler was a silent warning/skip — release proceeded without the upload

## Fix
- Added \--remote\ flag to all \wrangler r2 object put\ calls
- Changed missing wrangler from \Write-Warn\ + skip to \Write-Error\ + \xit 1\

## Mitigation for v7.5.0
All 4 v7.5.0 binaries have been manually uploaded to R2 with \--remote\. The update dialog should work immediately.