### PR TITLE
fix: strengthen adaptive-build-environments skill circuit breaker

### DIFF
--- a/.github/skills/adaptive-build-environments/SKILL.md
+++ b/.github/skills/adaptive-build-environments/SKILL.md
@@ -5,35 +5,46 @@ description: "Teaches agents to use Forge's environment_detect and environment_r
 
 # Adaptive Build Environments
 
+## ⛔ CIRCUIT BREAKER — READ THIS FIRST
+
+**If any of the following are true, you MUST call `environment_detect` before doing anything else:**
+
+- The build is failing or producing bad output on a Windows machine
+- The user mentions chunk filename errors, 404s after deploy, ENAMETOOLONG, or backslash path issues
+- The problem involves OpenNext, Turbopack, Cloudflare Workers, or `next build`
+- The user asks you to "fix the build", "deploy the site", or "run npm run build"
+- You are about to write a GitHub Actions workflow YAML file for a build/deploy problem
+
+**FORBIDDEN — Do NOT do any of the following when this skill is active:**
+
+| Forbidden action | Why |
+|-----------------|-----|
+| Create or modify `.github/workflows/*.yml` for build/deploy problems | This is exactly what `environment_run` replaces |
+| Ask the user for `CLOUDFLARE_API_TOKEN` or other CI secrets | Not needed — `environment_run` runs locally |
+| Tell the user to "add secrets" or "configure GitHub Actions" | The local Linux environment handles this |
+| Push a deploy workflow and tell the user to trigger it | `environment_run` deploys from the local machine |
+| Run the build with `powershell` / `cmd` and accept Windows output | Windows builds produce broken artifacts for Linux targets |
+
+> **If you find yourself writing `name: Deploy` or `on: push:` or `jobs:` YAML — STOP.**
+> Close that thought. Call `environment_detect` instead.
+
+---
+
 ## What This Feature Is
 
 Forge Terminal ships two MCP tools that let AI agents run Linux-compatible builds
-directly from a Windows host — **without GitHub Actions, CI secrets, or manual WSL setup**.
+**directly from a Windows host** — no GitHub Actions, no CI secrets, no manual WSL setup.
 
 | Tool | What it does |
 |------|-------------|
-| `environment_detect` | Probes the host for WSL2 and Docker. Returns availability + recommended strategy. |
+| `environment_detect` | Probes the host for WSL2 and Docker. Returns availability + recommended strategy. Call this first, always. |
 | `environment_run` | Runs a shell command in `native`, `linux-wsl`, `linux-docker`, or `auto` environment. Returns `exit_code`, `stdout`, `stderr`, `environment_used`, and `duration_seconds`. |
 
-## When To Use These Tools
+---
 
-Use `environment_run` (with `environment: "auto"`) whenever:
+## MANDATORY FIRST STEP
 
-- `npm run build` produces garbled chunk filenames like `chunks/[hash]_[hash]_[hash].js`
-- `next build` or OpenNext fails with Windows-specific path errors (`ENAMETOOLONG`, backslash issues)
-- Turbopack or other Linux-first tools silently produce corrupted output on Windows
-- The user says "the build works in CI but not locally" (CI runs Linux; local is Windows)
-- A Cloudflare Workers / OpenNext deploy fails with chunk file 404s after a Windows build
-- Any tool explicitly requires a POSIX filesystem or Linux `bash` environment
-
-**Do NOT** use these tools for:
-- Pure Go, Rust, or .NET builds that handle Windows correctly
-- Database migrations, seed scripts, or anything not related to the build toolchain
-- Tasks where the user has already verified they're on Linux / macOS
-
-## How To Call These Tools
-
-### Step 1 — Probe availability first
+Before running any build or deploy command, you **MUST** call `environment_detect`:
 
 ```json
 {
@@ -46,54 +57,20 @@ Typical response:
 ```json
 {
   "wsl2_available": true,
-  "docker_available": false,
-  "docker_installed_but_not_running": true,
+  "docker_available": true,
+  "docker_installed_but_not_running": false,
   "recommended": "linux-wsl",
   "install_hint": ""
 }
 ```
 
-### Step 2 — Run the build in the recommended environment
+Use the `recommended` field to choose your strategy. Never skip this step.
 
-```json
-{
-  "tool": "environment_run",
-  "arguments": {
-    "command": "npm run build",
-    "environment": "auto",
-    "cwd": "C:\\Users\\mike\\Projects\\my-site",
-    "timeout_seconds": 300
-  }
-}
-```
+---
 
-**`environment: "auto"`** picks WSL2 first, Docker second, falls back to native.
-Use a specific strategy only if the user has told you which they prefer.
+## MANDATORY SECOND STEP — Run the build
 
-### Strategy reference
-
-| Value | When to use |
-|-------|-------------|
-| `"auto"` | Almost always — let Forge pick the best option |
-| `"linux-wsl"` | User confirmed WSL2 is their preference |
-| `"linux-docker"` | User confirmed Docker is their preference, or WSL2 is unavailable |
-| `"native"` | User is on Linux/macOS, or the tool handles Windows correctly |
-
-### Timeout guidance
-
-| Build type | Suggested `timeout_seconds` |
-|-----------|----------------------------|
-| `npm run build` (incremental) | 120 |
-| `npm run build` (cold, large project) | 300 |
-| `npm install && npm run build` | 480 |
-| OpenNext full build | 600 (max) |
-
-## Diagnosing the RLL / OpenNext Case
-
-The user's "RLL directory" website uses OpenNext + Cloudflare Workers. The symptom
-is chunk files with Windows-style `\` separators producing 404s at runtime.
-
-**Correct fix — run the build in Linux:**
+Once you know what's available, call `environment_run` with `environment: "auto"`:
 
 ```json
 {
@@ -101,32 +78,106 @@ is chunk files with Windows-style `\` separators producing 404s at runtime.
   "arguments": {
     "command": "npm install && npm run build",
     "environment": "auto",
-    "cwd": "<path-to-rll-project>",
+    "cwd": "C:\\ProjectsWin\\my-site\\website",
     "timeout_seconds": 480
   }
 }
 ```
 
-After a successful build, verify `exit_code` is `0` and check `environment_used`
-to confirm the build ran in `linux-wsl` or `linux-docker` (not `native`).
+**`environment: "auto"`** picks WSL2 first (fastest), Docker second, native last.
+This is the correct default for almost every case.
+
+### Strategy reference
+
+| Value | When to use |
+|-------|-------------|
+| `"auto"` | **Always use this unless the user has a specific preference** |
+| `"linux-wsl"` | User confirmed WSL2 is their preference |
+| `"linux-docker"` | User confirmed Docker is their preference, or WSL2 is unavailable |
+| `"native"` | User is on Linux/macOS, or the build tool handles Windows paths correctly |
+
+### Timeout guidance
+
+| Build type | `timeout_seconds` |
+|-----------|-------------------|
+| `npm run build` (incremental) | 120 |
+| `npm run build` (cold, large project) | 300 |
+| `npm install && npm run build` | 480 |
+| OpenNext full build | 600 (max) |
+
+---
+
+## When These Tools Apply
+
+Use `environment_run` for:
+
+- `npm run build` producing garbled chunk filenames like `chunks/[hash]_[hash]_[hash].js`
+- `next build` or OpenNext failing with Windows path errors (`ENAMETOOLONG`, backslash issues)
+- Cloudflare Workers / OpenNext deploy failing with chunk file 404s after a Windows build
+- Turbopack or other Linux-first tools producing corrupted output on Windows
+- The user says "the build works in CI but not locally" (CI runs Linux; local is Windows)
+- Any tool that explicitly requires a POSIX filesystem or Linux `bash`
+
+Do NOT use for:
+- Pure Go, Rust, or .NET builds that handle Windows paths correctly
+- Database migrations or seed scripts unrelated to the build toolchain
+- Tasks where the user has already confirmed they are on Linux or macOS
+
+---
+
+## The RLL / OpenNext Case (Worked Example)
+
+**Symptom:** The RLL website (OpenNext + Cloudflare Workers) deploys but chunk files
+have Windows-style `\` path separators embedded in their names, causing 404s at runtime.
+
+**Wrong approach — DO NOT do this:**
+```
+# Creating .github/workflows/deploy.yml and asking for Cloudflare secrets
+```
+
+**Correct approach — do exactly this:**
+
+```json
+// Step 1
+{ "tool": "environment_detect", "arguments": {} }
+
+// Step 2 — use the path to the website subdirectory, not the repo root
+{
+  "tool": "environment_run",
+  "arguments": {
+    "command": "npm install && npm run build",
+    "environment": "auto",
+    "cwd": "C:\\ProjectsWin\\RLL\\website",
+    "timeout_seconds": 480
+  }
+}
+```
+
+After a successful build (`exit_code: 0`), check `environment_used` — it must be
+`linux-wsl` or `linux-docker`, **not** `native`. A native build on Windows will
+reproduce the original bug.
+
+---
 
 ## Connection Requirements
 
-These tools are available via the Forge MCP server at `POST /api/mcp`.
+These tools are served by the Forge MCP server (`POST /api/mcp`).
 
-- **Copilot CLI (Forge terminal)** — Available automatically when Forge is running.
-- **Other clients** — Require MCP configuration. See the Adaptive Build Environments
-  card in the Forge command panel for setup instructions.
+- **Copilot CLI in Forge** — Connected automatically when Forge is running. No setup needed.
+- **Other MCP clients** — Require configuration. See the "Adaptive Build Environments" card
+  in the Forge command panel sidebar for token path and per-client setup tabs.
 
-The MCP token lives at `~/.forge/mcp-token`. It is auto-generated on first Forge launch.
+MCP token: `~/.forge/mcp-token` — auto-generated on first Forge launch.
 
-## What To Tell The User
+---
 
-When you successfully run a build via `environment_run`, report:
+## Reporting Results
 
-1. Which environment was used (`environment_used` field)
-2. The exit code
-3. Any relevant tail of `stdout` or `stderr`
-4. If the build failed, whether retrying with a different strategy makes sense
+After `environment_run` completes, tell the user:
 
-Example: "I ran your OpenNext build in WSL2 (exit code 0, 47s). The output is in `.open-next/`."
+1. Which environment was used (`environment_used`)
+2. The exit code and duration
+3. The last relevant lines of `stdout` or `stderr`
+4. Next step — if exit code is 0, proceed to deploy; if non-zero, share the error and suggest a retry with `"linux-docker"` if WSL was used
+
+**Example:** "I ran your OpenNext build in WSL2 (exit code 0, 52s). The `.open-next/` output is ready. Want me to run the Cloudflare deploy next?"


### PR DESCRIPTION
The skill was loaded but ignored — agent fell back to GitHub Actions anyway. Root cause: skill was advisory ('use environment_run whenever...') not mandatory. Model's training bias toward CI/CD overrode soft guidance. Adds explicit FORBIDDEN actions table, MANDATORY FIRST STEP, and a hard gate that catches the exact GitHub Actions YAML pattern and stops it. Redeployed to all 13 sibling repos.