### PR TITLE
fix: suppress console window in environment_run; prefer PTY for builds

### DIFF
--- a/.github/skills/adaptive-build-environments/SKILL.md
+++ b/.github/skills/adaptive-build-environments/SKILL.md
@@ -30,6 +30,38 @@ description: "Teaches agents to use Forge's environment_detect and environment_r
 
 ---
 
+## Preferred Approach: Run in the Active Forge Tab
+
+**Forge IS a terminal app.** Before using `environment_run`, try the PTY-first approach:
+
+1. Call `terminal_sessions` to list active Forge sessions
+2. Pick the session that is already in (or closest to) the project directory
+3. Call `terminal_execute` with the WSL command directly — the user sees output live in their tab
+
+```json
+// Step 1 — find the active session
+{ "tool": "terminal_sessions", "arguments": {} }
+
+// Step 2 — cd and build inside the existing Forge terminal
+{
+  "tool": "terminal_execute",
+  "arguments": {
+    "session_id": "<id from step 1>",
+    "command": "wsl -e bash -c 'cd /mnt/c/ProjectsWin/RLL/website && npm install && npm run build'",
+    "timeout_seconds": 480
+  }
+}
+```
+
+**Why this is better:** Output streams live in the user's terminal tab. No hidden background process. No external window. The user sees progress in real time, exactly as if they ran it themselves.
+
+**Fall back to `environment_run`** only when:
+- No active Forge PTY session exists
+- The session is on the wrong machine (remote session)
+- You need structured JSON output with `exit_code`, `environment_used`, and `duration_seconds`
+
+---
+
 ## What This Feature Is
 
 Forge Terminal ships two MCP tools that let AI agents run Linux-compatible builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`adaptive-build-environments` Copilot skill** — Deployed to all Forge-managed repos. Teaches agents when and how to call `environment_detect` and `environment_run` when builds fail on Windows (OpenNext, Turbopack, chunk path issues). Includes the RLL/OpenNext specific diagnosis and correct command pattern.
 
 ### Fixed
+- **`environment_run` no longer opens an external terminal window** — Added `CREATE_NO_WINDOW` process creation flag on Windows so `wsl.exe` and `cmd.exe` run headlessly. Since Forge is a terminal, spawning a separate console window was always wrong.
+- **`terminal_execute` timeout raised 30s → 600s** — Agents can now use `terminal_execute` (which streams output live in the active Forge tab) for long-running builds, not just quick commands.
+- **`adaptive-build-environments` skill updated** — Agents now prefer `terminal_sessions` + `terminal_execute` (PTY-first, user sees live output) over `environment_run` for builds. Skill redeployed to 13 sibling repos.
+
+### Fixed
 - **Release script R2 upload**— `local-release.ps1` now passes `--remote` to `wrangler r2 object put` so binaries are uploaded to Cloudflare R2 rather than the local wrangler dev instance. Missing `wrangler` is now a hard error (exit 1) instead of a silent skip, preventing 404 download failures for licensed users.
 
 ## [7.5.0] - 2026-04-21

--- a/internal/mcp/environment_runner.go
+++ b/internal/mcp/environment_runner.go
@@ -91,8 +91,12 @@ type realCommandRunner struct{}
 
 // RunCommand forks a child process, captures stdout and stderr separately,
 // and returns them along with the exit code.
+//
+// suppressConsoleWindow is called before Start so that wsl.exe and cmd.exe
+// do not pop a visible terminal window when Forge itself is the terminal.
 func (r *realCommandRunner) RunCommand(ctx context.Context, name string, args []string) (RunOutput, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	suppressConsoleWindow(cmd) // platform-specific; no-op on non-Windows
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 	cmd.Stdout = &stdoutBuffer

--- a/internal/mcp/environment_runner_unix.go
+++ b/internal/mcp/environment_runner_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+// environment_runner_unix.go — non-Windows stub for suppressConsoleWindow.
+// On Linux and macOS, console window suppression is not needed; child processes
+// never open a GUI window unless explicitly programmed to do so.
+
+package mcp
+
+import "os/exec"
+
+// suppressConsoleWindow is a no-op on non-Windows platforms.
+func suppressConsoleWindow(_ *exec.Cmd) {}

--- a/internal/mcp/environment_runner_unix_test.go
+++ b/internal/mcp/environment_runner_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+// environment_runner_unix_test.go verifies that suppressConsoleWindow is a
+// safe no-op on non-Windows platforms — it must not panic or set any fields.
+package mcp
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSuppressConsoleWindowIsNoOpOnUnix(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("echo", "test")
+	// SysProcAttr is nil before the call on all platforms.
+	suppressConsoleWindow(cmd)
+	// On non-Windows the stub must leave SysProcAttr unchanged (nil).
+	if cmd.SysProcAttr != nil {
+		t.Error("expected suppressConsoleWindow to be a no-op on non-Windows (SysProcAttr should remain nil)")
+	}
+}

--- a/internal/mcp/environment_runner_windows.go
+++ b/internal/mcp/environment_runner_windows.go
@@ -1,0 +1,26 @@
+// environment_runner_windows.go — Windows-specific process creation flags for
+// the environment runner. Without these flags, spawning console applications
+// like wsl.exe or cmd.exe from a background goroutine pops a visible terminal
+// window, which is wrong when Forge itself is the terminal.
+
+package mcp
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNoWindowFlag tells Windows not to allocate a new console window for
+// the child process. This is the correct flag when the parent process already
+// manages its own terminal (as Forge does).
+const createNoWindowFlag = 0x08000000
+
+// suppressConsoleWindow configures the command to run headlessly on Windows.
+// The child process inherits stdin/stdout/stderr from the Go buffers we attach,
+// so output is captured correctly — just without the popup.
+func suppressConsoleWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: createNoWindowFlag,
+	}
+}

--- a/internal/mcp/environment_runner_windows_test.go
+++ b/internal/mcp/environment_runner_windows_test.go
@@ -1,0 +1,25 @@
+// environment_runner_windows_test.go verifies that the Windows-specific
+// suppressConsoleWindow function sets the expected SysProcAttr fields.
+package mcp
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSuppressConsoleWindowSetsHideWindowOnWindows(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("echo", "test")
+	suppressConsoleWindow(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected SysProcAttr to be set, got nil")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("expected HideWindow to be true")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindowFlag == 0 {
+		t.Errorf("expected CreationFlags to include CREATE_NO_WINDOW (0x%08x), got 0x%08x",
+			createNoWindowFlag, cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/internal/mcp/tools_terminal.go
+++ b/internal/mcp/tools_terminal.go
@@ -24,7 +24,9 @@ const (
 	defaultExecuteTimeoutSec = 3
 
 	// maxExecuteTimeoutSec is the hard upper limit for terminal_execute waits.
-	maxExecuteTimeoutSec = 30
+	// 600 seconds (10 minutes) matches environment_run so agents can use
+	// terminal_execute for long-running builds that stream live in the Forge tab.
+	maxExecuteTimeoutSec = 600
 
 	// executeOutputPollInterval is how often terminal_execute checks for new output.
 	executeOutputPollInterval = 100 * time.Millisecond
@@ -98,7 +100,7 @@ func (t *terminalExecuteTool) Definition() ToolDefinition {
 				},
 				"timeout_seconds": {
 					"type": "number",
-					"description": "How long to wait for output (1-30). Defaults to 3 seconds."
+					"description": "How long to wait for output (1-600). Defaults to 3 seconds. Use 300-600 for builds."
 				}
 			},
 			"required": ["session_id", "command"]


### PR DESCRIPTION
Forge is a terminal app — environment_run was spawning wsl.exe in a new visible Windows console window. Adds CREATE_NO_WINDOW syscall flag. Also raises terminal_execute timeout 30s→600s so agents can route builds through the active Forge tab instead, and updates the skill to prefer that PTY-first approach.