### PR TITLE
fix: mouse-mode reset, bracketed paste, and project-root resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Mouse clicks still injected escape sequences in *restored* tabs (carryover from v7.7.2).** The previous fix only reset xterm.js mouse-tracking modes inside the OSC 9;9 prompt-arrived handler, so it never ran on tabs reattached after an update — those tabs reattach to an existing PTY mid-session and may not see a fresh prompt for some time. `ForgeTerminal.jsx` now writes the same six disable sequences immediately after `term.open()`, before the WebSocket connects, guaranteeing a clean state on every mount regardless of restoration path.
+- **Command-card macro payloads silently corrupted multi-line workflow prompts to AI CLIs.** `sendCommand` previously sent the entire payload as a single send followed by a synthetic `\r`, with no special handling for embedded newlines. Receiving TUIs (Copilot CLI, Claude Code, etc.) interpreted each `\n` as Enter mid-payload, submitting partial prompts and dropping the rest. `sendCommand` now detects newlines and wraps multi-line payloads in xterm bracketed-paste markers (`\x1b[200~ ... \x1b[201~`) with normalized line endings, so the receiving TUI treats the entire payload as one paste event and only acts on it after the closing marker.
+- **Forge Workflow card (Enterprise Workflow card) detected wrong project root from subfolder terminals.** When the active terminal's CWD was a subfolder (e.g. `forge-terminal/frontend`), `/api/workflow/status`, `/api/workflow/compliance`, and `/api/workflow/preflight` all scanned the subfolder rather than the project root — so the card showed missing CHANGELOG, missing `.github/`, and false compliance failures. The handlers now walk up from the supplied path to the nearest project marker (`.git`, `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`) before scanning, so every subfolder of a project sees the same workflow state as the root.
+
 ## [7.7.2] - 2026-04-25
 
 ---

--- a/cmd/forge/handlers_workflow.go
+++ b/cmd/forge/handlers_workflow.go
@@ -238,6 +238,10 @@ func handleWorkflowStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "query parameter 'path' is required", http.StatusBadRequest)
 		return
 	}
+	// Walk up to the actual project root so a CWD inside any subfolder
+	// (e.g. .../forge-terminal/frontend) returns the same status as the
+	// project root itself.
+	projectPath = resolveProjectRoot(projectPath)
 
 	status := workflow.WorkflowStatus{
 		Configured: false,
@@ -281,6 +285,8 @@ func handleWorkflowCompliance(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "query parameter 'path' is required", http.StatusBadRequest)
 		return
 	}
+	// Resolve to project root so subfolders inherit the project's compliance.
+	projectPath = resolveProjectRoot(projectPath)
 
 	// Load the project's workflow config, or use defaults
 	config, err := readWorkflowConfig(projectPath)
@@ -317,6 +323,54 @@ func handleWorkflowModules(w http.ResponseWriter, r *http.Request) {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+// resolveProjectRoot walks up from the given path until it finds a marker
+// that identifies a project root (.git directory, package.json, go.mod, or
+// pyproject.toml). If none is found, it returns the original path unchanged.
+//
+// Why this exists: the workflow API receives the active terminal's CWD as
+// its `path` parameter. When a user has cd'd into a subfolder of their
+// project (e.g. C:\ProjectsWin\forge-terminal\frontend), the workflow card
+// previously scanned the subfolder and missed the actual project's
+// configuration, .github/, and CHANGELOG. Resolving up to the nearest
+// marker gives every subfolder of a project the same workflow context.
+func resolveProjectRoot(startPath string) string {
+	if startPath == "" {
+		return startPath
+	}
+	absolutePath, err := filepath.Abs(startPath)
+	if err != nil {
+		return startPath
+	}
+	currentPath := absolutePath
+	// Walk up at most 20 levels — enough for any realistic checkout depth
+	// without risking an infinite loop on weird filesystem topologies.
+	for i := 0; i < 20; i++ {
+		if isProjectRootMarker(currentPath) {
+			return currentPath
+		}
+		parentPath := filepath.Dir(currentPath)
+		if parentPath == currentPath {
+			break // hit filesystem root
+		}
+		currentPath = parentPath
+	}
+	return startPath
+}
+
+// isProjectRootMarker reports whether the given directory contains any
+// marker file that identifies it as the root of a project.
+func isProjectRootMarker(dirPath string) bool {
+	if _, err := os.Stat(filepath.Join(dirPath, ".git")); err == nil {
+		return true
+	}
+	for _, markerFile := range []string{"package.json", "go.mod", "pyproject.toml", "Cargo.toml"} {
+		if _, err := os.Stat(filepath.Join(dirPath, markerFile)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // readWorkflowConfig reads and parses .forge/workflow.json from a project path.
 func readWorkflowConfig(projectPath string) (workflow.WorkflowConfig, error) {
 	configPath := filepath.Join(projectPath, ".forge", "workflow.json")
@@ -350,6 +404,9 @@ func handleReleasePreflight(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "query parameter 'path' is required", http.StatusBadRequest)
 		return
 	}
+	// Resolve to project root so a release scan triggered from any subfolder
+	// audits the same files the local-release script would.
+	projectPath = resolveProjectRoot(projectPath)
 
 	targetVersion := r.URL.Query().Get("version")
 

--- a/cmd/forge/handlers_workflow_root_test.go
+++ b/cmd/forge/handlers_workflow_root_test.go
@@ -1,0 +1,93 @@
+// Tests for the project-root resolver used by the workflow handlers.
+//
+// These ensure that a workflow API call made from any subfolder of a project
+// finds the same project root as a call made from the root itself, so the
+// Forge Workflow card shows consistent compliance regardless of which
+// folder the active terminal happens to be in.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveProjectRoot_FromGitSubdir verifies that a path inside a .git
+// repository walks up to the directory containing .git/.
+func TestResolveProjectRoot_FromGitSubdir(t *testing.T) {
+	rootPath := t.TempDir()
+	// Create a fake project with a .git directory and a deep subfolder.
+	gitDirPath := filepath.Join(rootPath, ".git")
+	if err := os.Mkdir(gitDirPath, 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	deepSubfolderPath := filepath.Join(rootPath, "frontend", "src", "components")
+	if err := os.MkdirAll(deepSubfolderPath, 0o755); err != nil {
+		t.Fatalf("failed to create deep subfolder: %v", err)
+	}
+
+	resolvedPath := resolveProjectRoot(deepSubfolderPath)
+	expectedPath, _ := filepath.Abs(rootPath)
+	if resolvedPath != expectedPath {
+		t.Errorf("expected %q, got %q", expectedPath, resolvedPath)
+	}
+}
+
+// TestResolveProjectRoot_FromPackageJson verifies package.json is also a marker.
+func TestResolveProjectRoot_FromPackageJson(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootPath, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write package.json: %v", err)
+	}
+	subfolderPath := filepath.Join(rootPath, "src")
+	if err := os.MkdirAll(subfolderPath, 0o755); err != nil {
+		t.Fatalf("failed to create subfolder: %v", err)
+	}
+
+	resolvedPath := resolveProjectRoot(subfolderPath)
+	expectedPath, _ := filepath.Abs(rootPath)
+	if resolvedPath != expectedPath {
+		t.Errorf("expected %q, got %q", expectedPath, resolvedPath)
+	}
+}
+
+// TestResolveProjectRoot_AlreadyAtRoot returns the same path when called on
+// the root itself.
+func TestResolveProjectRoot_AlreadyAtRoot(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootPath, "go.mod"), []byte("module x"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+
+	resolvedPath := resolveProjectRoot(rootPath)
+	expectedPath, _ := filepath.Abs(rootPath)
+	if resolvedPath != expectedPath {
+		t.Errorf("expected %q, got %q", expectedPath, resolvedPath)
+	}
+}
+
+// TestResolveProjectRoot_NoMarkers returns the original path unchanged when
+// no project markers are found anywhere up the tree.
+func TestResolveProjectRoot_NoMarkers(t *testing.T) {
+	rootPath := t.TempDir()
+	subfolderPath := filepath.Join(rootPath, "loose-files")
+	if err := os.MkdirAll(subfolderPath, 0o755); err != nil {
+		t.Fatalf("failed to create subfolder: %v", err)
+	}
+
+	// Resolver may walk all the way up to filesystem root; on most CI machines
+	// the temp dir is itself inside a checkout, so we just verify it does NOT
+	// blow up and returns a non-empty string.
+	resolvedPath := resolveProjectRoot(subfolderPath)
+	if resolvedPath == "" {
+		t.Error("expected non-empty result, got empty string")
+	}
+}
+
+// TestResolveProjectRoot_EmptyInput returns the empty input unchanged.
+func TestResolveProjectRoot_EmptyInput(t *testing.T) {
+	if resolveProjectRoot("") != "" {
+		t.Error("expected empty string for empty input")
+	}
+}

--- a/frontend/src/components/ForgeTerminal.jsx
+++ b/frontend/src/components/ForgeTerminal.jsx
@@ -786,6 +786,33 @@ const ForgeTerminal = forwardRef(function ForgeTerminal({
 
         const executionDelay = (delay !== undefined && delay !== null) ? parseInt(delay, 10) : 15;
 
+        // Detect multi-line payloads (typical for command-card macro_payload
+        // values that inject a workflow prompt into an AI CLI). Without
+        // bracketed-paste mode, every embedded `\n` is interpreted by the
+        // receiving TUI as Enter — submitting partial prompts and corrupting
+        // the macro. Bracketed paste tells the TUI to treat the entire
+        // chunk as one paste event and only act on it after the closing
+        // marker arrives.
+        const hasNewlines = /\r|\n/.test(command);
+        if (hasNewlines) {
+          // Normalize line endings to '\r' (CR) so receiving TUIs that
+          // honor bracketed-paste see consistent line breaks. Some TUIs
+          // treat the LF half of CRLF as a literal newline character mid-
+          // paste; CR alone matches xterm's documented bracketed-paste
+          // behavior most reliably.
+          const normalized = command.replace(/\r\n/g, '\r').replace(/\n/g, '\r');
+          const bracketed = '\x1b[200~' + normalized + '\x1b[201~';
+          wsRef.current.send(bracketed);
+          // After the closing bracket, give the TUI time to ingest the
+          // paste event before sending the trailing Enter that submits it.
+          setTimeout(() => {
+            if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+              wsRef.current.send('\r');
+            }
+          }, executionDelay);
+          return true;
+        }
+
         // For large inputs (>8KB), chunk to avoid WebSocket frame issues
         const CHUNK_SIZE = 8192;
         if (command.length > CHUNK_SIZE) {
@@ -1167,6 +1194,23 @@ const ForgeTerminal = forwardRef(function ForgeTerminal({
     term.open(terminalRef.current);
     xtermRef.current = term;
     diagnosticCore.recordInitEvent('xterm_created', { tabId });
+
+    // Reset xterm.js mouse-tracking modes immediately on mount.
+    //
+    // Why this is needed at mount time (in addition to the OSC 9;9 handler):
+    // when a tab is "restored" from a prior session, xterm.js is freshly
+    // constructed but the underlying PTY may already have a TUI running
+    // (vim, htop, fzf, an AI CLI menu) that previously enabled mouse
+    // reporting. The first replayed bytes from the PTY can re-enable those
+    // modes before any new prompt fires — so the OSC 9;9 reset never gets
+    // a chance to run, and clicks immediately start injecting raw escape
+    // sequences like "\e[<0;44;37M" into the shell.
+    //
+    // Writing the disable sequences to term.write() updates xterm.js's
+    // internal mode state without sending anything to the PTY. They are
+    // no-ops when the modes are already off, so it is safe to run on
+    // every mount unconditionally.
+    term.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?1015l');
 
     // Track scroll position to show/hide the "scroll to bottom" button.
     //


### PR DESCRIPTION
Ships three carryover fixes from the v7.7.2 issue list.

## Issue 1 — Mouse-as-keystrokes on restored tabs (carryover from v7.7.2)
v7.7.2 only ran the mouse-mode disable sequences inside the OSC 9;9 prompt-arrived handler. Restored tabs reattach to a mid-session PTY where no fresh prompt fires, so the reset never ran. Now writes the six \\\x1b[?100Xl\ sequences immediately after \	erm.open()\, before WS connect.

## Issue 2 — Multi-line macro payloads dropped by AI CLIs
\sendCommand\ previously sent the payload then a synthetic \\\r\ after 15ms. Multi-line workflow prompts contain \\\n\, which receiving TUIs treated as Enter mid-payload — submitting partial prompts and dropping the rest. Now wraps multi-line payloads in xterm bracketed-paste markers (\\\x1b[200~...\\x1b[201~\) with CRLF→CR normalization.

## Issue 4 — Forge Workflow card detected wrong project root
\/api/workflow/{status,compliance,preflight}\ scanned whatever folder the active terminal's CWD pointed to. From a subfolder this missed CHANGELOG, .github/, etc. Handlers now walk up to the nearest \.git\/\package.json\/\go.mod\/\pyproject.toml\/\Cargo.toml\ before scanning. Includes unit tests.

## Deferred
- **Issue 5 (recovered tab lockup):** needs reproduction + diagnostic logging; speculative fix risks making it worse.
- **Issue 3 (rename Enterprise → Forge Workflow):** mechanical rename, separate PR.
- **Issue 6 (real workflow enforcement):** design synthesized in plan.md; tracked as follow-up.

## Verification
- \go build ./cmd/forge/\ ✅
- \go test ./cmd/forge/ -run TestResolveProjectRoot\ ✅
- \
px vitest run\ — 177 tests pass ✅