### PR TITLE
feat: auto-install pre-commit hook on first gate record

### DIFF
--- a/.github/skills/workflow-enforcer/SKILL.md
+++ b/.github/skills/workflow-enforcer/SKILL.md
@@ -216,6 +216,10 @@ forge workflow preflight
 ```
 
 **One-time install of the hook in any new repo:**
+The hook is **installed automatically** the first time `workflow_gate_record` is called
+in a project (i.e., when the very first ticket is created).  No manual step is required.
+
+If for any reason you need to force-reinstall or install without recording a gate:
 ```powershell
 .\scripts\install-workflow-hooks.ps1   # Windows
 ./scripts/install-workflow-hooks.sh    # macOS / Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.8.0] - 2026-04-25
+## [7.8.1] - 2026-04-25
+
+### Changed
+- **Workflow pre-commit hook is now auto-installed.** Previously developers had to run `scripts/install-workflow-hooks.{ps1,sh}` once per repository. Now `internal/workflow/ticket.go` calls `EnsureHookInstalled` automatically the first time `RecordGate` creates a new ticket for a project — so any agent (or human) that records their first gate also silently gets the hook. The installer scripts remain available for manual re-installation. The hook preserves any existing non-Forge pre-commit script rather than overwriting it.
+
+
 
 ---
 

--- a/internal/workflow/hooks.go
+++ b/internal/workflow/hooks.go
@@ -1,0 +1,135 @@
+// hooks.go — automatic pre-commit hook installation for the workflow gate system.
+//
+// EnsureHookInstalled is called the first time RecordGate creates a new ticket
+// for a project, so developers (and agents) never need to remember a manual
+// install step.  The function is idempotent: calling it a second time is always
+// a safe no-op.
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// hookMarker is the magic string embedded in every Forge-managed hook script.
+// Its presence means the hook was installed by Forge and is safe to skip on
+// subsequent calls.
+const hookMarker = "# forge-hook-v1"
+
+// EnsureHookInstalled idempotently writes the Forge pre-commit hook to
+// <projectRoot>/.git/hooks/pre-commit.
+//
+// Behaviour matrix:
+//   - No .git directory          → silent no-op (bare repo, git worktree file, etc.)
+//   - Hook absent                → write our hook and make it executable
+//   - Hook present with marker   → skip (already installed)
+//   - Hook present without marker → skip (preserve user's existing hook)
+//
+// Errors are returned to the caller, but RecordGate treats them as
+// best-effort and never blocks gate recording because of a hook-install failure.
+func EnsureHookInstalled(projectRoot string) error {
+	gitPath := filepath.Join(projectRoot, ".git")
+
+	// If .git doesn't exist this is not a standard git working tree — skip.
+	if _, statErr := os.Stat(gitPath); os.IsNotExist(statErr) {
+		return nil
+	}
+
+	hooksDir := filepath.Join(gitPath, "hooks")
+	if mkErr := os.MkdirAll(hooksDir, 0o755); mkErr != nil {
+		return mkErr
+	}
+
+	hookPath := filepath.Join(hooksDir, "pre-commit")
+
+	// Read any existing hook to decide whether we should write.
+	existing, readErr := os.ReadFile(hookPath)
+	if readErr == nil {
+		if strings.Contains(string(existing), hookMarker) {
+			return nil // Already installed — nothing to do.
+		}
+		// A hook exists but was written by a different tool.  Leave it alone so
+		// we don't silently discard a user's custom pre-commit logic.
+		return nil
+	}
+	if !os.IsNotExist(readErr) {
+		return readErr // Unexpected I/O error.
+	}
+
+	// No hook exists yet — write ours.
+	return os.WriteFile(hookPath, []byte(preCommitHookScript()), 0o755)
+}
+
+// preCommitHookScript returns the POSIX shell script written to pre-commit.
+//
+// The script is intentionally identical in behaviour to the one produced by
+// scripts/install-workflow-hooks.{ps1,sh} so that manually re-running the
+// installer produces the same result.  Any changes here should be mirrored
+// in those scripts (and vice-versa).
+func preCommitHookScript() string {
+	lines := []string{
+		"#!/usr/bin/env sh",
+		hookMarker,
+		"# Forge Terminal — runtime workflow pre-commit gate.",
+		"# Auto-installed by 'forge workflow record'; safe to regenerate via",
+		"# scripts/install-workflow-hooks.{ps1,sh}.",
+		"",
+		"set -e",
+		"",
+		`if [ "${FORGE_BYPASS:-0}" = "1" ]; then`,
+		`  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")`,
+		`  reason="${FORGE_BYPASS_REASON:-no reason provided}"`,
+		`  mkdir -p .forge`,
+		`  printf "%s bypass: %s\n" "$ts" "$reason" >> .forge/bypasses.log`,
+		`  echo "[forge] FORGE_BYPASS=1 — workflow gate skipped, logged to .forge/bypasses.log"`,
+		`  exit 0`,
+		`fi`,
+		"",
+		"# Refuse commits straight to main / master.",
+		`branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")`,
+		`case "$branch" in`,
+		"  main|master)",
+		`    echo "[forge] BLOCKED: refusing to commit directly to '$branch'." >&2`,
+		`    echo "[forge] Create a feature branch first (e.g. 'git checkout -b feature/foo')." >&2`,
+		`    echo "[forge] Set FORGE_BYPASS=1 with FORGE_BYPASS_REASON=... to override." >&2`,
+		`    exit 1`,
+		`    ;;`,
+		"esac",
+		"",
+		"# Locate a forge binary.  Prefer the project-local build, then PATH.",
+		`forge_bin=""`,
+		`if [ -x "./forge" ]; then forge_bin="./forge"`,
+		`elif [ -x "./fterm.exe" ]; then forge_bin="./fterm.exe"`,
+		`elif [ -x "./forge.exe" ]; then forge_bin="./forge.exe"`,
+		`elif command -v forge >/dev/null 2>&1; then forge_bin="forge"`,
+		`elif command -v fterm >/dev/null 2>&1; then forge_bin="fterm"`,
+		`fi`,
+		"",
+		`if [ -z "$forge_bin" ]; then`,
+		`  echo "[forge] WARNING: forge binary not found — skipping ticket preflight." >&2`,
+		`  echo "[forge] Install Forge Terminal or run from a built source tree to enable enforcement." >&2`,
+		`  exit 0`,
+		`fi`,
+		"",
+		"# Run preflight.  Exit code 2 = required gates missing.",
+		`"$forge_bin" workflow preflight`,
+		`status=$?`,
+		`if [ "$status" -eq 0 ]; then`,
+		`  echo "[forge] workflow gate: PASS"`,
+		`  exit 0`,
+		`fi`,
+		`if [ "$status" -eq 2 ]; then`,
+		`  echo "" >&2`,
+		`  echo "[forge] BLOCKED: workflow ticket is missing required gates." >&2`,
+		`  echo "[forge] Record gates via the workflow_gate_record MCP tool, then retry." >&2`,
+		`  echo "[forge] Required gates: branch-created, tests-written, tests-passed." >&2`,
+		`  echo "[forge] Override with FORGE_BYPASS=1 FORGE_BYPASS_REASON=... git commit ..." >&2`,
+		`  exit 1`,
+		`fi`,
+		`echo "[forge] preflight returned unexpected status $status — blocking commit." >&2`,
+		`exit 1`,
+		"",
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/workflow/hooks_test.go
+++ b/internal/workflow/hooks_test.go
@@ -1,0 +1,97 @@
+// hooks_test.go — verifies EnsureHookInstalled behaviour across all four cases.
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeGitDir creates a minimal .git directory in root so EnsureHookInstalled
+// treats it as a real git working tree.
+func makeGitDir(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("makeGitDir: %v", err)
+	}
+}
+
+func TestEnsureHookInstalled_InstallsOnFreshRepo(t *testing.T) {
+	dir := t.TempDir()
+	makeGitDir(t, dir)
+
+	if err := EnsureHookInstalled(dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "pre-commit"))
+	if err != nil {
+		t.Fatalf("hook file not created: %v", err)
+	}
+	if !strings.Contains(string(content), hookMarker) {
+		t.Error("installed hook is missing the forge marker")
+	}
+	if !strings.Contains(string(content), "workflow preflight") {
+		t.Error("installed hook does not call 'workflow preflight'")
+	}
+}
+
+func TestEnsureHookInstalled_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	makeGitDir(t, dir)
+
+	// Install once, record the content.
+	if err := EnsureHookInstalled(dir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	hookPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
+	firstContent, _ := os.ReadFile(hookPath)
+	firstInfo, _ := os.Stat(hookPath)
+
+	// Install again — must be a no-op (content and mtime unchanged).
+	if err := EnsureHookInstalled(dir); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	secondContent, _ := os.ReadFile(hookPath)
+	secondInfo, _ := os.Stat(hookPath)
+
+	if string(firstContent) != string(secondContent) {
+		t.Error("hook content changed on second call — idempotency violated")
+	}
+	if firstInfo.ModTime() != secondInfo.ModTime() {
+		t.Error("hook mtime changed on second call — file was rewritten unnecessarily")
+	}
+}
+
+func TestEnsureHookInstalled_PreservesForeignHook(t *testing.T) {
+	dir := t.TempDir()
+	makeGitDir(t, dir)
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	foreignContent := "#!/bin/sh\necho 'my custom hook'\n"
+	hookPath := filepath.Join(hooksDir, "pre-commit")
+	if err := os.WriteFile(hookPath, []byte(foreignContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureHookInstalled(dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := os.ReadFile(hookPath)
+	if string(got) != foreignContent {
+		t.Error("EnsureHookInstalled overwrote an existing non-Forge pre-commit hook")
+	}
+}
+
+func TestEnsureHookInstalled_NoopWithoutGitDir(t *testing.T) {
+	dir := t.TempDir()
+	// No .git directory at all — must succeed silently.
+	if err := EnsureHookInstalled(dir); err != nil {
+		t.Fatalf("expected nil error when .git is absent, got: %v", err)
+	}
+}

--- a/internal/workflow/ticket.go
+++ b/internal/workflow/ticket.go
@@ -140,6 +140,10 @@ func RecordGate(projectRoot, taskID, gate, evidence string) (*Ticket, error) {
 	if ticket == nil || (taskID != "" && ticket.TaskID != taskID) {
 		// New task starts a fresh ledger so gate evidence cannot leak across tasks.
 		ticket = &Ticket{TaskID: taskID, StartedAt: time.Now().UTC()}
+		// Auto-install the pre-commit hook the first time a ticket is created for
+		// this project.  Best-effort: a hook-install failure is never surfaced to
+		// the caller — it should not block an agent from recording gate evidence.
+		_ = EnsureHookInstalled(projectRoot)
 	}
 	ticket.Gates = append(ticket.Gates, GateRecord{
 		Gate:     gate,


### PR DESCRIPTION
Makes the Forge pre-commit hook automatic. EnsureHookInstalled is called from RecordGate on new ticket creation. Idempotent, preserves foreign hooks, silent no-op when .git absent. 4 new tests in hooks_test.go.