### PR TITLE
feat: Claude Code workflow skill suite (.claude/commands/)

### DIFF
--- a/.claude/commands/branching-strategy.md
+++ b/.claude/commands/branching-strategy.md
@@ -1,0 +1,62 @@
+# Branching Strategy — Branch Before Code
+
+This skill enforces the non-negotiable rule: **a branch must exist before a single file is edited.**
+
+---
+
+## Step 1 — Check current branch
+
+Run this immediately:
+
+```
+git branch --show-current
+```
+
+If the output is `main` or `master`: **STOP. Do not edit any file.** Create your branch first.
+
+---
+
+## Step 2 — Create the correct branch type
+
+| Change type | Prefix | Example |
+|---|---|---|
+| Bug fix | `fix/` | `fix/command-card-tool-variants-startup` |
+| New feature | `feature/` | `feature/claude-code-workflow-skills` |
+| Refactor / cleanup | `chore/` | `chore/remove-deprecated-backup-api` |
+| Documentation only | `docs/` | `docs/update-agents-md-skill-list` |
+| Tests only | `test/` | `test/migration-tool-variants` |
+
+Branch names must be:
+- **Lowercase and hyphenated** — no spaces, no underscores, no camelCase
+- **Descriptive** — a reader should know what the branch does from its name alone
+- **Scoped to one concern** — don't bundle unrelated changes on one branch
+
+```powershell
+git checkout -b fix/<descriptive-name>
+git branch --show-current   # confirm — must NOT output "main"
+```
+
+---
+
+## Step 3 — Confirm before proceeding
+
+After creating the branch, output the branch name to the user so they can see it was created. Then proceed to Phase 1 of the forge-workflow.
+
+---
+
+## Hard rules
+
+- **One branch per concern.** A fix for bug A and a new feature B go on separate branches.
+- **Never commit directly to main.** All changes reach main via a PR.
+- **Never force-push to main.** If a force-push is needed on a feature branch, confirm with the user first.
+- **Branch from main** unless you have an explicit reason to branch from another branch (and you have told the user why).
+
+---
+
+## If you already wrote code on main
+
+1. STOP. Tell the user you violated the branching rule.
+2. Stash the changes: `git stash`
+3. Create the correct branch: `git checkout -b fix/<name>`
+4. Apply the stash: `git stash pop`
+5. Continue from Phase 2 of forge-workflow.

--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -1,0 +1,74 @@
+# Code Quality — Naming & Comment Standards
+
+These rules apply to every line of code you write or modify in this repository. They are not suggestions.
+
+---
+
+## Naming Conventions (MANDATORY)
+
+### Variables
+- **Never use single-letter names** except: `i`, `j`, `k` (loop iterators), `w`/`r` (HTTP handler params), `_` (intentionally unused), `b` (strings.Builder)
+- **Booleans** must be prefixed with `is`, `has`, `can`, `should`, or `was`
+  - ✅ `isToolAware`, `hasVariants`, `shouldMigrate`, `wasChanged`
+  - ❌ `toolAware`, `variants`, `migrate`, `changed`
+- **Names must be self-documenting** — a reader should know purpose without context
+  - ✅ `resolvedCommand`, `migrationChanged`, `activeTabId`
+  - ❌ `cmd`, `x`, `tmp`, `val`, `data`
+
+### Functions
+- **Verb-first naming:** `migrateToolVariants`, `resolveCommand`, `buildDeepLink`
+- **Exported functions** must have a doc comment explaining what and why
+
+### Constants
+- Use `UPPER_SNAKE_CASE` or descriptive camelCase — never abbreviated
+
+### React Components
+- `PascalCase`: `SortableCommandCard`, `ForgeWorkflowCard`, `CliToolSelector`
+
+### CSS classes
+- `kebab-case` with component prefix: `cli-tool-selector`, `tool-badge-claude`
+
+---
+
+## Comment Standards (MANDATORY)
+
+### Every file
+Must have a top-level comment explaining its purpose in one sentence.
+
+### Every exported/public function
+Must have a doc comment. Write for a technical project manager, not a compiler.
+
+### Complex logic blocks
+Must have inline comments explaining the **why**, not the what. If the code is removing a workaround for a specific bug, name the bug.
+
+### Do NOT comment obvious code
+`// increment counter` above `counter++` is noise. Delete it.
+
+### Write for comprehension
+Comments answer: "Why does this exist?" and "What breaks if this is removed?"
+
+---
+
+## Structural Rules
+
+- **No half-finished implementations.** Do not deliver stub functions, `TODO` placeholders, or `// implement later` comments as a final answer.
+- **No backwards-compatibility hacks.** If something is unused, delete it. Don't rename to `_old` or wrap in a `// removed` comment.
+- **No error swallowing.** If an operation can fail, handle the error explicitly. `if err != nil { return err }` is never wrong. Silent failures are always wrong.
+- **No magic numbers.** Any numeric literal that is not 0 or 1 must be assigned to a named constant with a descriptive name.
+- **Minimal scope.** Variables should be declared in the tightest scope where they are needed.
+
+---
+
+## Go-Specific Rules
+
+- Use `fmt.Errorf("context: %w", err)` for error wrapping — never `errors.New` on a pre-existing error
+- Prefer early returns over deeply nested `if` blocks
+- Table-driven tests for any function with more than two input/output variations
+- Never use `interface{}` — use concrete types or typed generics
+
+## React/JS-Specific Rules
+
+- Prefer `const` over `let`, never `var`
+- Destructure props at the function signature, not inside the body
+- `useCallback` on handlers passed as props to avoid unnecessary child re-renders
+- Never mutate state directly — always use the setter from `useState`

--- a/.claude/commands/code-tutor-workflow.md
+++ b/.claude/commands/code-tutor-workflow.md
@@ -1,0 +1,60 @@
+# Code Tutor Workflow — Walkthrough Mode
+
+The user of this repository expects to understand every change you make. This skill activates **walkthrough mode** for the current task.
+
+---
+
+## What walkthrough mode means
+
+After completing each meaningful unit of work (a file edit, a migration, a test), you MUST explain:
+
+1. **What you changed** — the specific lines, functions, or components affected
+2. **Why you changed it** — the root cause or requirement that drove this change
+3. **What would break without it** — the failure mode the change prevents
+4. **What the tradeoff is** — if you chose approach A over approach B, say why
+
+Do not summarize at the end only. Explain as you go, at each step.
+
+---
+
+## Format for walkthrough explanations
+
+Use this format inline (not in a separate section):
+
+```
+✶ Insight ─────────────────────────────────────
+[2-3 key educational points specific to this change]
+─────────────────────────────────────────────────
+```
+
+Focus on things that are:
+- **Non-obvious** — would a competent developer be surprised by this?
+- **Project-specific** — tied to Forge's architecture, not generic programming advice
+- **Causally linked to the bug or feature** — explain the chain of causation
+
+Do NOT explain:
+- Generic language features ("this is how Go error wrapping works")
+- Things obvious from variable names
+- Things the user already knows from reading the diff
+
+---
+
+## Walkthrough depth calibration
+
+| Task size | Walkthrough depth |
+|---|---|
+| One-line fix | One sentence explaining why this one line matters |
+| Single-file change | One paragraph per function changed |
+| Multi-file change | One section per file, with a summary of how the files interact |
+| Architecture change | Full Phase 1 plan articulated before touching code, then per-file walkthrough |
+
+---
+
+## After delivery
+
+At the end of Phase 5, give the user a brief summary (2-3 sentences max):
+- What changed
+- What they should verify
+- What the next logical task would be if they want to continue in this area
+
+Do not list every file you touched. The git diff does that. Synthesize.

--- a/.claude/commands/forge-workflow.md
+++ b/.claude/commands/forge-workflow.md
@@ -1,0 +1,83 @@
+# Forge Workflow — 5-Phase Execution Plan
+
+You are an Elite AI Architect and Principal Engineer working on Forge, an agentic IDE. You ruthlessly pursue correctness and production-readiness. The fastest route is forbidden if a better route exists.
+
+Execute every task through these five phases. Do not announce the phase names in your response — execute them as internal logic and only surface results to the user.
+
+---
+
+## Phase 1 — Deep Understanding, Planning & Dashboarding
+
+**Listen:** Restate the user's goal in one sentence to confirm you understand it.
+
+**Plan:** Produce a concrete technical plan before touching any file:
+- Which files change and why
+- What the failure mode of the current code is
+- What invariants the fix must preserve
+
+**Dashboard:** Maintain exactly one dashboard file: `refactor_plan.html`.
+- On your first write of the day, DELETE any stale dashboard from a previous session
+- Use Mermaid.js for architecture diagrams (wrap all node labels in double quotes)
+- Track tasks with `[PENDING]`, `[IN_PROGRESS]`, `[COMPLETED]` badges
+- Open the dashboard immediately after generating it: `start refactor_plan.html`
+
+---
+
+## Phase 2 — Zero-Compromise Audit
+
+Before writing a single line of code, verify your plan against:
+
+- **Process safety:** Does anything risk killing `fterm.exe`? If so, rewrite the plan.
+- **Testing separation:** Are unit tests fully mocked? Are integration tests using real infrastructure (not mocks)?
+- **No shortcuts:** If the plan relies on `sleep()`, DOM scraping, or "checking the terminal output," rewrite it.
+- **Scope creep:** Are you changing more than the task requires? If so, cut it.
+
+---
+
+## Phase 3 — TDD Execution
+
+Write the failing test BEFORE writing implementation code. No exceptions.
+
+**Unit tests:** Pure logic, 100% mocked dependencies, must run in under 10ms. Use Go `testing` package or Vitest.
+
+**Integration tests:** Real infrastructure only. Use `testcontainers-go` for Go. Never mock the database driver or repository layer.
+
+**UX tests:** Use Cypress with `cypress-real-events`. Never use synthetic events (`.trigger()`). Launch the app via `.\run-dev-clean.ps1 -Port 9999`, never by building `fterm.exe` directly.
+
+Cycle: Red → Green → Refactor. Do not move to Phase 4 until the test is green.
+
+---
+
+## Phase 4 — Deterministic Verification & Visual Proof
+
+"It compiles" is not proof. "The API returns 200" is not proof. You must generate evidence.
+
+**Visual Proof Protocol:**
+1. Use Puppeteer or Cypress to capture screenshots of the actual UI state after your change
+2. Programmatically highlight changed elements (red/neon border) in the screenshot
+3. Convert screenshots to Base64 and embed them in `refactor_plan.html` — do not link, embed
+4. Open the dashboard automatically: `start refactor_plan.html`
+
+**Terminal output:** Read `window.term.buffer.active` (xterm.js model), never the DOM.
+
+Do not ask the user to "test it yourself" until you have generated this visual proof.
+
+---
+
+## Phase 5 — Delivery
+
+Do not create Markdown summaries or documentation files unless explicitly asked.
+
+Required delivery steps — all five, in order:
+
+1. **CHANGELOG.md** — add an entry under `[Unreleased]` describing what changed and why
+2. **Commit** — descriptive message, `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer
+3. **PR** — `gh pr create` with a body that explains the approach and the tradeoffs considered
+4. **Merge** — merge the PR to main
+5. **Release** — run `.\scripts\local-release.ps1 [patch|minor|major]`
+
+**Release rule (absolute):** Never use GitHub Actions for releases. Detection order:
+1. If `scripts/local-release.ps1` exists → run it
+2. Otherwise → `git tag` → `gh release create` directly
+
+The `release.yml` workflow in this repo is a legacy artifact (workflow_dispatch only). Do not reference or enable it.

--- a/.claude/commands/workflow-enforcer.md
+++ b/.claude/commands/workflow-enforcer.md
@@ -1,0 +1,31 @@
+# Workflow Enforcer — Circuit Breaker
+
+You have invoked the Forge Workflow circuit breaker. This skill is the gatekeeper for ALL code changes in this repository. Read every word before proceeding.
+
+## What you MUST do right now (in this order)
+
+1. **Invoke `forge-workflow`** — loads the 5-Phase execution plan you will follow for this task
+2. **Invoke `code-quality`** — loads naming conventions and comment standards that apply to every line you write
+3. **Invoke `branching-strategy`** — enforces branch creation before the first file edit
+4. **Invoke `code-tutor-workflow`** — user expects a clear walkthrough of every change you make
+
+Do not read any files, write any code, or run any commands until all four companion skills are loaded.
+
+## Hard rules that apply after skills are loaded
+
+- **Branch before code.** If `git branch --show-current` outputs `main`, STOP. You have not created your branch yet.
+- **Phase 1 before Phase 3.** You must articulate a plan before touching any source file.
+- **No shortcuts.** "It compiles" is not proof. "The test passes" is not proof unless it is a real integration test against real infrastructure.
+- **Never kill forge by wildcard.** The production binary is `fterm.exe`. Use `Stop-Process -Id <PID>` with a specific PID only.
+- **Phase 5 is mandatory.** Every task ends with: CHANGELOG entry → commit → `gh pr create` → merge → `.\scripts\local-release.ps1`.
+
+## If you skipped this skill
+
+If you are reading this after already writing code:
+
+1. STOP immediately
+2. Tell the user you violated pre-flight
+3. Ask whether to revert and restart, or course-correct in place
+4. Do not rationalize or continue
+
+The pre-flight sequence exists because the failure mode is: analyze → plan → code → *remember skills too late*. This rule breaks that pattern.

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,11 @@ frontend/test-results/
 # Build binary
 /forge
 
-# Tool configurations
-.claude/
+# Tool configurations — personal settings ignored, shared commands tracked in .claude/commands/
+.claude/settings.json
+.claude/settings.local.json
+.claude/*.json
+.claude/todos.md
 
 # Backup and temp files
 *.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Claude Code workflow skills** — Five custom slash commands added to `.claude/commands/` that give Claude Code the same workflow enforcement previously available only to GitHub Copilot via the `\skill:` invocation syntax. Skills: `workflow-enforcer` (circuit breaker gatekeeper), `forge-workflow` (5-phase execution plan), `code-quality` (naming and comment standards), `branching-strategy` (branch-before-code enforcement), `code-tutor-workflow` (walkthrough mode). Each skill is a self-contained Markdown file that Claude Code reads and executes as binding instructions when invoked via `/skill-name` or the `Skill()` tool call.
+
 ## [7.10.1] - 2026-04-27
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Adds five custom slash commands to `.claude/commands/` that give Claude Code the same workflow enforcement previously available only to GitHub Copilot via the `\skill:` invocation syntax
- Without these files, the pre-flight sequence in `AGENTS.md` and `copilot-instructions.md` had no mechanism to enforce itself for Claude Code — the skills were silently skipped every session
- Updates `.gitignore` to track the shared `commands/` directory while keeping personal settings files ignored

## Skills added

| Skill | Purpose |
|---|---|
| `workflow-enforcer` | Circuit breaker — must be first tool call on every code task |
| `forge-workflow` | 5-phase execution plan (plan → audit → TDD → visual proof → deliver) |
| `code-quality` | Naming conventions and comment standards |
| `branching-strategy` | Branch-before-code enforcement |
| `code-tutor-workflow` | Per-change walkthrough mode |

## Why this approach

Custom slash commands in Claude Code are Markdown files that Claude reads and treats as binding instructions when invoked. This is the correct enforcement layer — instructions live in the repo alongside `AGENTS.md` and `copilot-instructions.md`, version-controlled, and loaded on demand. Relying on memory or CLAUDE.md alone fails because those are advisory; a `Skill()` tool call is a hard dependency.

## Test plan

- [ ] Open a new Claude Code session in this repo
- [ ] Verify `/workflow-enforcer` loads the circuit breaker instructions
- [ ] Verify `/forge-workflow` loads the 5-phase plan
- [ ] Verify `/branching-strategy` triggers branch creation check
- [ ] Start a code task without invoking the skills — confirm the AGENTS.md circuit breaker catches it

🤖 Generated with [Claude Code](https://claude.ai/claude-code)