### PR TITLE
fix: release manager no longer polls wrong project after tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Background Release Manager: polling no longer uses the wrong project after tab switch** — `readReleaseJobStatus` previously closed over `releaseRepoPath`, a live-computed value derived from `cwd`. When the user switched tabs mid-release, `cwd` changed, `releaseRepoPath` updated to the new project, and all subsequent poll requests sent the old job ID paired with the new project path — causing 404 errors and corrupted job state. Fix: `activeJobRepoPath` state is now snapshot from `releaseRepoPath` the moment a job starts and frozen for the lifetime of that job. The fetch helper is a pure function with empty dependency array that accepts explicit `(jobId, jobRepoPath)` parameters; it never closes over live CWD-derived values.
+- **Background Release Manager: stale in-flight poll responses no longer corrupt state** — The old callback called `setActiveReleaseJob` internally, before the polling effect could check `shouldContinuePolling`. A response in-flight during a tab switch could therefore overwrite state with data from the previous project. Fix: `fetchReleaseJobStatus` now returns data only; all state mutations happen inside the polling effect, after the `shouldContinuePolling` guard.
+- **Background Release Manager: toast completion/failure messages now use the job's own version** — Previously used the live `next` version computed from the current tab, which diverged after a tab switch. Now uses `result.job.version` from the polled response.
+- **Background Release Manager: concurrent write/read race on job.json eliminated** — Each HTTP request previously created a new `ReleaseJobStore` with a fresh `sync.RWMutex`, so the background release goroutine and HTTP poll handlers never actually shared a lock. A poll arriving mid-write could read a partially written file, producing "unexpected end of JSON input". Fix: a package-level `sync.Map` registry now ensures all `ReleaseJobStore` instances for the same canonical project root share one `*sync.RWMutex`. Path canonicalisation uses `filepath.Abs` + `filepath.Clean` + lowercase normalisation on Windows so that case variants and relative paths resolve to the same lock.
+
 ## [7.10.26] - 2026-05-28
 
 ---

--- a/frontend/src/components/OwnerReleaseCard.jsx
+++ b/frontend/src/components/OwnerReleaseCard.jsx
@@ -40,6 +40,9 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
   const [includeUncommittedChanges, setIncludeUncommittedChanges] = useState(false);
   const [shouldProceedWithWarnings, setShouldProceedWithWarnings] = useState(false);
   const [activeReleaseJob, setActiveReleaseJob] = useState(null);
+  // activeJobRepoPath is frozen at the moment a job starts so that polling always
+  // targets the original repo regardless of which tab is active while the job runs.
+  const [activeJobRepoPath, setActiveJobRepoPath] = useState(null);
   const [releaseJobLog, setReleaseJobLog] = useState('');
   const [releaseJobError, setReleaseJobError] = useState(null);
   const [isSubmittingRelease, setIsSubmittingRelease] = useState(false);
@@ -323,10 +326,13 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
     }
   }, [hasLocalScript, releaseRepoPath, releaseCommand, next, onExecuteCommand]);
 
-  const readReleaseJobStatus = useCallback(async (jobId) => {
-    if (!releaseRepoPath || !jobId) return;
+  // fetchReleaseJobStatus is a pure fetch helper with no state mutations.
+  // It deliberately does NOT close over `releaseRepoPath` — callers must pass the
+  // repo path explicitly so that stale closures from a previous tab never corrupt state.
+  const fetchReleaseJobStatus = useCallback(async (jobId, jobRepoPath) => {
+    if (!jobRepoPath || !jobId) return null;
     const query = new URLSearchParams({
-      repoPath: releaseRepoPath,
+      repoPath: jobRepoPath,
       jobId,
       maxLogBytes: '20000',
     });
@@ -335,36 +341,46 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
     if (!response.ok) {
       throw new Error(body.error || 'Failed to read release job status');
     }
-    setActiveReleaseJob(body.job);
-    setReleaseJobLog(body.log || '');
-    return body.job;
-  }, [releaseRepoPath]);
+    return { job: body.job, log: body.log || '' };
+  }, []); // Empty deps — never changes, never closes over live CWD-derived values
 
   useEffect(() => {
     if (!activeReleaseJob || !activeReleaseJob.job_id) return undefined;
     if (activeReleaseJob.status === 'completed' || activeReleaseJob.status === 'failed') return undefined;
+    if (!activeJobRepoPath) return undefined;
+
+    // Freeze the job context at effect-creation time.
+    // If the user switches tabs while this job runs, cwd changes but these frozen
+    // values stay correct for the duration of this particular effect invocation.
+    const frozenJobId = activeReleaseJob.job_id;
+    const frozenRepoPath = activeJobRepoPath;
 
     let shouldContinuePolling = true;
     let failedPollCount = 0;
     const pollReleaseJob = async () => {
       try {
-        const latestJob = await readReleaseJobStatus(activeReleaseJob.job_id);
-        if (!shouldContinuePolling || !latestJob) return;
+        const result = await fetchReleaseJobStatus(frozenJobId, frozenRepoPath);
+        // Guard: discard result if polling was cancelled during the async fetch.
+        if (!shouldContinuePolling || !result) return;
+        setActiveReleaseJob(result.job);
+        setReleaseJobLog(result.log);
         failedPollCount = 0;
-        if (latestJob.status === 'completed') {
-          if (onToast) onToast(`Release ${next} completed`, 'success', 5000);
+        if (result.job.status === 'completed') {
+          if (onToast) onToast(`Release ${result.job.version} completed`, 'success', 5000);
           shouldContinuePolling = false;
+          setActiveJobRepoPath(null);
         }
-        if (latestJob.status === 'failed') {
-          if (onToast) onToast(`Release ${next} failed`, 'error', 6000);
+        if (result.job.status === 'failed') {
+          if (onToast) onToast(`Release ${result.job.version} failed`, 'error', 6000);
           shouldContinuePolling = false;
+          setActiveJobRepoPath(null);
         }
       } catch (err) {
         failedPollCount += 1;
         setReleaseJobError(err.message);
         if (failedPollCount >= 3) {
           shouldContinuePolling = false;
-          if (onToast) onToast(`Release ${next} status polling paused`, 'warning', 5000);
+          if (onToast) onToast(`Release status polling paused`, 'warning', 5000);
         }
       }
     };
@@ -374,13 +390,18 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
       shouldContinuePolling = false;
       clearInterval(pollTimer);
     };
-  }, [activeReleaseJob?.job_id, activeReleaseJob?.status, readReleaseJobStatus, onToast, next]);
+  }, [activeReleaseJob?.job_id, activeReleaseJob?.status, activeJobRepoPath, fetchReleaseJobStatus, onToast]);
 
   const startBackgroundRelease = useCallback(async () => {
     if (!releaseRepoPath || !releaseVersionNumber || !releaseNotes.trim()) {
       setReleaseJobError('Release notes are required for background releases.');
       return;
     }
+
+    // Snapshot the repo path NOW, before any async work.
+    // This frozen value travels with the job so that polling never drifts to the
+    // current tab's CWD when the user switches tabs while the release is running.
+    const frozenRepoPath = releaseRepoPath;
 
     setIsSubmittingRelease(true);
     setReleaseJobError(null);
@@ -389,7 +410,7 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repoPath: releaseRepoPath,
+          repoPath: frozenRepoPath,
           version: releaseVersionNumber,
           releaseNotes,
           includeUncommittedChanges,
@@ -401,6 +422,7 @@ const OwnerReleaseCard = ({ onExecuteCommand, onToast, shellType, cwd }) => {
         throw new Error(body.error || 'Failed to start release job');
       }
       setActiveReleaseJob(body.job);
+      setActiveJobRepoPath(frozenRepoPath);
       setReleaseJobLog(body.log || '');
       setShowReleaseModal(false);
       if (onToast) onToast(`Release ${next} started in the background`, 'info', 3000);

--- a/internal/releasejobs/release_jobs.go
+++ b/internal/releasejobs/release_jobs.go
@@ -20,6 +20,36 @@ import (
 	"github.com/google/uuid"
 )
 
+// projectMutexRegistry holds one shared RWMutex per canonical project root path.
+// This ensures that the background release goroutine and HTTP polling handlers always
+// synchronize on the same lock, even though each HTTP request creates a fresh store.
+var projectMutexRegistry sync.Map // map[string]*sync.RWMutex
+
+// sharedMutexForPath returns the canonical shared mutex for a project root, creating
+// one on first access. Two paths that resolve to the same directory share one mutex.
+func sharedMutexForPath(projectRoot string) *sync.RWMutex {
+	registryKey := canonicalProjectPath(projectRoot)
+	newMutex := &sync.RWMutex{}
+	actual, _ := projectMutexRegistry.LoadOrStore(registryKey, newMutex)
+	return actual.(*sync.RWMutex)
+}
+
+// canonicalProjectPath produces a stable, case-normalized registry key from any path form.
+// It resolves to an absolute path so that relative paths, trailing slashes, and (on Windows)
+// letter-case differences all map to the same key.
+func canonicalProjectPath(rawPath string) string {
+	absPath, absErr := filepath.Abs(rawPath)
+	if absErr != nil {
+		absPath = rawPath
+	}
+	clean := filepath.Clean(absPath)
+	// Windows NTFS is case-insensitive; normalise to lowercase so C:\Repo and c:\repo are the same key.
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(clean)
+	}
+	return clean
+}
+
 const (
 	releaseJobsDirectoryName = "release-jobs"
 	releaseJobMetadataFile   = "job.json"
@@ -90,18 +120,27 @@ type ReleaseProcessRunner interface {
 }
 
 // ReleaseJobStore owns on-disk metadata and logs for release jobs in one repository.
+// mu is a shared pointer so that all store instances for the same project root—including
+// the background goroutine and each HTTP polling handler—synchronise on one lock.
 type ReleaseJobStore struct {
 	projectRoot string
 	jobsRoot    string
-	mu          sync.RWMutex
+	mu          *sync.RWMutex
 }
 
 // NewReleaseJobStore creates a store rooted at <repo>/.forge/release-jobs.
+// Stores with the same canonical project root share a single mutex so that the
+// background release goroutine and concurrent HTTP poll requests never race on job.json.
 func NewReleaseJobStore(projectRoot string) *ReleaseJobStore {
-	cleanProjectRoot := filepath.Clean(projectRoot)
+	absPath, absErr := filepath.Abs(projectRoot)
+	if absErr != nil {
+		absPath = projectRoot
+	}
+	cleanProjectRoot := filepath.Clean(absPath)
 	return &ReleaseJobStore{
 		projectRoot: cleanProjectRoot,
 		jobsRoot:    filepath.Join(cleanProjectRoot, ".forge", releaseJobsDirectoryName),
+		mu:          sharedMutexForPath(projectRoot),
 	}
 }
 


### PR DESCRIPTION
## Problem

Two bugs caused background release job monitoring to break when the user switched tabs while a release was in progress.

### Bug 1: Wrong project path after tab switch

`readReleaseJobStatus` closed over `releaseRepoPath`, a live-computed value derived from `cwd`. When the user switched tabs mid-release, `cwd` changed and `releaseRepoPath` updated to the new project. The callback was recreated (it listed `releaseRepoPath` in its dep array), and all subsequent polls sent the old job ID paired with the new project path - producing the corrupted-path error seen in the screenshots.

### Bug 2: Torn JSON read ("unexpected end of JSON input")

Each HTTP request called `NewReleaseJobStore(repoPath)` which created a brand-new store with a fresh `sync.RWMutex`. The background goroutine and poll handlers each held a different mutex for the same files - they never actually serialized. A poll arriving mid-write read a partially written job.json.

## Fix

### Frontend (OwnerReleaseCard.jsx)
- Added `activeJobRepoPath` state, snapshot at job start, never drifts with tab switches
- Renamed to `fetchReleaseJobStatus`: pure fetch, empty dep array, explicit `(jobId, jobRepoPath)` params
- Polling effect captures frozen values at creation time; state mutations only after the shouldContinuePolling guard
- Toast messages use `result.job.version` from polled response instead of live `next`

### Backend (internal/releasejobs/release_jobs.go)
- `projectMutexRegistry sync.Map` maps canonical project root to `*sync.RWMutex`
- `ReleaseJobStore.mu` changed to shared pointer so all store instances for same repo share one lock
- Path canonicalization: filepath.Abs + filepath.Clean + lowercase on Windows

## Tests
- 242 frontend tests pass
- 5 backend release job tests pass
- go build clean, vite build clean
