### PR TITLE
fix: sync tab naming from server on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Tab naming strategy now applied on startup**: On every app launch, Forge now
+  fetches `/api/tab-defaults` after session restore and calls `retitleAllTabsFromCwd`
+  with the server-authoritative strategy. Previously, `useTabNaming` read only from
+  `localStorage`, which could be stale or missing; if `localStorage` defaulted to
+  `'project-root'`, any tabs saved with `"Terminal N"` titles (from a prior numbered
+  session) would be re-derived into directory-based project names — showing "3D Repos",
+  "3D Printing", etc. instead of the user's configured strategy.
+
 ## [7.11.7] - 2026-06-05
 
 ---

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -233,7 +233,26 @@ function App() {
     reorderTabs,
     retitleAllTabsFromCwd,
   } = useTabManager(shellConfig, defaultTabTheme, namingStrategy, namingPrefix, namingRootFolder);
-  
+
+  // On startup, sync the tab naming strategy from the server after session
+  // restore completes. localStorage may be stale or missing — the server's
+  // tab-defaults.json is authoritative. Without this, session restore runs
+  // with the default 'project-root' strategy and re-derives any "Terminal N"
+  // saved titles (from a prior 'numbered' session) into directory-based names.
+  useEffect(() => {
+    if (!sessionLoaded) return;
+    fetch('/api/tab-defaults')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data?.namingStrategy) return;
+        setNamingStrategy(data.namingStrategy);
+        setNamingPrefix(data.namingPrefix || 'Dev');
+        setNamingRootFolder(data.namingRootFolder || '');
+        retitleAllTabsFromCwd(data.namingStrategy, data.namingPrefix || 'Dev', data.namingRootFolder || '');
+      })
+      .catch(() => {});
+  }, [sessionLoaded, setNamingStrategy, setNamingPrefix, setNamingRootFolder, retitleAllTabsFromCwd]);
+
   // DevMode state
   const { devMode, setDevMode, isInitialized: devModeInitialized } = useDevMode();
   

--- a/frontend/src/hooks/useTabManager.test.js
+++ b/frontend/src/hooks/useTabManager.test.js
@@ -1,0 +1,129 @@
+// Tests for useTabManager session restore + startup sync behaviour.
+//
+// Core invariant guarded here: when localStorage loses the user's naming
+// strategy (e.g. cleared cache, fresh install), the session restore runs
+// with the default 'project-root' strategy and re-derives any "Terminal N"
+// saved titles into directory-based project names.  The startup sync
+// (a useEffect in App.jsx that fetches /api/tab-defaults after sessionLoaded
+// becomes true) corrects this by calling retitleAllTabsFromCwd with the
+// server-authoritative strategy.
+import { act, renderHook } from '@testing-library/react'
+import { useTabManager } from './useTabManager'
+
+const makeSession = (tabs) => ({
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+})
+
+describe('useTabManager — session restore re-derivation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('re-derives "Terminal N" saved titles to project-root names when localStorage strategy is stale', async () => {
+    // Arrange: session has numbered-style titles from a previous run under 'numbered'
+    // strategy, but localStorage lost that key → useTabManager defaults to 'project-root'.
+    const session = makeSession([
+      {
+        id: 'tab-1',
+        title: 'Terminal 1',
+        currentDirectory: 'C:/ProjectsWin/3d-repos',
+        shellConfig: { shellType: 'powershell', wslDistro: '', wslHomePath: '' },
+      },
+    ])
+
+    global.fetch = vi.fn((url) =>
+      url === '/api/sessions'
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(session) })
+        : Promise.resolve({ ok: true, json: () => Promise.resolve(null) })
+    )
+
+    const { result } = renderHook(() =>
+      useTabManager({ shellType: 'powershell' }, 'auto-cycle', 'project-root', 'Dev', '')
+    )
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Bug condition: 'Terminal 1' triggers re-derivation (title starts with 'Terminal '),
+    // and project-root strategy converts the directory path to a project name.
+    const tab = result.current.tabs.find((t) => t.id === 'tab-1')
+    expect(tab?.title).toBe('3d-repos')
+  })
+
+  it('retitleAllTabsFromCwd with server strategy corrects project-root names back to numbered', async () => {
+    // Same setup — tab lands on "3d-repos" after stale-strategy restore.
+    const session = makeSession([
+      {
+        id: 'tab-1',
+        title: 'Terminal 1',
+        currentDirectory: 'C:/ProjectsWin/3d-repos',
+        shellConfig: { shellType: 'powershell', wslDistro: '', wslHomePath: '' },
+      },
+      {
+        id: 'tab-2',
+        title: 'Terminal 2',
+        currentDirectory: 'C:/ProjectsWin/3D-Printing',
+        shellConfig: { shellType: 'powershell', wslDistro: '', wslHomePath: '' },
+      },
+    ])
+
+    global.fetch = vi.fn((url) =>
+      url === '/api/sessions'
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(session) })
+        : Promise.resolve({ ok: true, json: () => Promise.resolve(null) })
+    )
+
+    const { result } = renderHook(() =>
+      useTabManager({ shellType: 'powershell' }, 'auto-cycle', 'project-root', 'Dev', '')
+    )
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Startup sync fires: /api/tab-defaults returns 'numbered';
+    // retitleAllTabsFromCwd is called with the correct server strategy.
+    act(() => {
+      result.current.retitleAllTabsFromCwd('numbered', 'Dev', '')
+    })
+
+    const tab1 = result.current.tabs.find((t) => t.id === 'tab-1')
+    const tab2 = result.current.tabs.find((t) => t.id === 'tab-2')
+    expect(tab1?.title).toBe('Terminal 1')
+    expect(tab2?.title).toBe('Terminal 2')
+  })
+
+  it('retitleAllTabsFromCwd with shell-type strategy replaces project names with shell labels', async () => {
+    const session = makeSession([
+      {
+        id: 'tab-1',
+        title: 'Terminal 1',
+        currentDirectory: 'C:/ProjectsWin/3d-repos',
+        shellConfig: { shellType: 'powershell', wslDistro: '', wslHomePath: '' },
+      },
+    ])
+
+    global.fetch = vi.fn((url) =>
+      url === '/api/sessions'
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(session) })
+        : Promise.resolve({ ok: true, json: () => Promise.resolve(null) })
+    )
+
+    const { result } = renderHook(() =>
+      useTabManager({ shellType: 'powershell' }, 'auto-cycle', 'project-root', 'Dev', '')
+    )
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    act(() => {
+      result.current.retitleAllTabsFromCwd('shell-type', 'Dev', '')
+    })
+
+    const tab = result.current.tabs.find((t) => t.id === 'tab-1')
+    expect(tab?.title).toBe('PowerShell 1')
+  })
+})


### PR DESCRIPTION
## Summary

- Tab names were reverting to project-root names (e.g. "3D Repos", "3D Printing") instead of respecting the user's saved naming strategy after an app restart.
- Root cause: `useTabNaming` reads from `localStorage` on startup; if that key is stale/missing it defaults to `'project-root'`. The session restore then re-derives any tab with a `"Terminal N"` title (saved from a prior `numbered` session) to a directory-based name via `getTabTitle`.
- Fix: `useEffect` in `App.jsx` fires once after `sessionLoaded` becomes true, fetches `/api/tab-defaults`, syncs the three naming setters to localStorage, then calls `retitleAllTabsFromCwd` to re-apply the server-authoritative strategy to all restored tabs.

## Test plan

- [ ] `useTabManager.test.js` — 3 new tests covering: (1) session restore reproduces the bug, (2) numbered strategy re-title corrects "3d-repos" → "Terminal 1", (3) shell-type strategy re-title produces "PowerShell 1"
- [ ] All 283 existing frontend tests pass (`npx vitest run`)
- [ ] Go build clean (`go build ./...`)
- [ ] Vite production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)