### PR TITLE
feat: install core workflow skills machine-wide via deploy-skills.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Core workflow skills now install machine-wide**: `scripts/deploy-skills.ps1`
+  hoists the five project-agnostic skills (`workflow-enforcer`, `code-quality`,
+  `framework-first`, `branching-strategy`, `code-tutor-workflow`) into the user-level
+  `~/.claude/skills/` directory, so every Claude Code project inherits them with no
+  per-repo copy (Claude Code resolves user-level skills natively). `forge-workflow` is
+  deliberately excluded — it hardcodes Forge Terminal's build commands and must stay
+  project-local. A new `-GlobalOnly` switch refreshes just the user-level set; a normal
+  full deploy keeps it in sync. This closes the gap where freshly scaffolded projects
+  (e.g. created from the Projects card) started with no workflow skills at all.
+
 ### Fixed
 - **Tab naming strategy now applied on startup**: On every app launch, Forge now
   fetches `/api/tab-defaults` after session restore and calls `retitleAllTabsFromCwd`

--- a/scripts/deploy-skills.ps1
+++ b/scripts/deploy-skills.ps1
@@ -8,9 +8,12 @@
 #   2. .claude/commands/<name>.md       — Claude Code reads these as project skills
 #   3. .github/copilot-instructions.md  — the FORGE-SKILLS marked section (GitHub Copilot)
 #
-# This deliberately does NOT touch the global ~/.claude/commands directory: skills are per-repo so a
-# Python project gets the generic skills, not another project's language-tuned ones. forge-terminal's
-# own language-tuned .claude/commands skills stay forge-local (see sync-skills.ps1).
+# Machine-wide skills: the project-AGNOSTIC subset ($globalSkills) is ALSO hoisted into the user-level
+# ~/.claude/skills directory, so every Claude Code project on this machine inherits the core workflow
+# skills WITHOUT per-repo replication (Claude Code natively resolves user-level skills). Forge-specific
+# skills — e.g. forge-workflow, which hardcodes Forge Terminal's build commands — are deliberately NOT
+# hoisted; they stay per-repo so they never override the workflow in unrelated projects. Use -GlobalOnly
+# to refresh just the user-level set without touching any repo.
 #
 # Usage:
 #   .\scripts\deploy-skills.ps1                  # deploy to all sibling git repos
@@ -21,7 +24,8 @@
 
 param(
     [string]$Target = "",
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$GlobalOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -48,6 +52,43 @@ $curatedSkills = @(
 $markerStart = '<!-- FORGE-SKILLS-START -->'
 $markerEnd   = '<!-- FORGE-SKILLS-END -->'
 
+# The subset of curated skills that are project-AGNOSTIC and safe to install machine-wide in
+# ~/.claude/skills (Claude Code user-level skills, inherited by every project without replication).
+# forge-workflow is deliberately excluded: it hardcodes Forge Terminal's build commands and must stay
+# project-local. workflow-enforcer self-detects project mode, so it degrades gracefully in any repo.
+$globalSkills = @(
+    'workflow-enforcer',
+    'code-quality',
+    'framework-first',
+    'branching-strategy',
+    'code-tutor-workflow'
+)
+
+# Write-GlobalUserSkills copies the project-agnostic skills into the user-level ~/.claude/skills
+# directory. This is what makes the core workflow skills appear in EVERY Claude Code project on the
+# machine with no per-repo copy — Claude Code natively resolves user-level skills, so we defer to that
+# mechanism instead of replicating files into each repo.
+function Write-GlobalUserSkills {
+    $globalSkillsDir = Join-Path $HOME ".claude\skills"
+    Write-Host "  --> ~/.claude/skills (machine-wide)" -ForegroundColor White
+    $hoistedCount = 0
+    foreach ($skillName in $globalSkills) {
+        $sourceFile = Join-Path $skillsSource "$skillName\SKILL.md"
+        if (-not (Test-Path $sourceFile)) {
+            Write-Host "      [--] $skillName missing from .github/skills - skipped" -ForegroundColor DarkGray
+            continue
+        }
+        $destDir  = Join-Path $globalSkillsDir $skillName
+        $destFile = Join-Path $destDir "SKILL.md"
+        if (-not $DryRun) {
+            New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+            Copy-Item -Path $sourceFile -Destination $destFile -Force
+        }
+        $hoistedCount++
+    }
+    Write-Host "      [OK] $hoistedCount generic skill(s) hoisted to user level" -ForegroundColor Green
+}
+
 Write-Host ""
 Write-Host "+================================================+" -ForegroundColor Cyan
 Write-Host "|   Forge Terminal - Deploy Skills (per-repo)    |" -ForegroundColor Cyan
@@ -57,6 +98,16 @@ Write-Host ""
 if ($DryRun) {
     Write-Host "  [DRY RUN] No files will be written." -ForegroundColor Yellow
     Write-Host ""
+}
+
+# -GlobalOnly refreshes the machine-wide user-level skills and skips the per-repo deploy entirely.
+# Use it after editing a skill master when you only need ~/.claude/skills brought up to date.
+if ($GlobalOnly) {
+    Write-GlobalUserSkills
+    Write-Host ""
+    Write-Host "  Global skill hoist complete$(if ($DryRun) { ' [DRY RUN]' })." -ForegroundColor Green
+    Write-Host ""
+    exit 0
 }
 
 # ── Collect target repos ───────────────────────────────────────────────────────
@@ -186,6 +237,10 @@ foreach ($repoPath in $targetRepos) {
     $successCount++
     Write-Host ""
 }
+
+# Keep the machine-wide user-level skills in sync on every full deploy, not just on -GlobalOnly.
+Write-GlobalUserSkills
+Write-Host ""
 
 Write-Host "+================================================+" -ForegroundColor Cyan
 Write-Host "  Skills deployed to $successCount repo(s)$(if ($DryRun) { ' [DRY RUN]' })" -ForegroundColor Green


### PR DESCRIPTION
## Problem

Freshly scaffolded projects (e.g. created from the Forge Projects card) start with **no workflow skills**. The only mechanism that placed skills into a project — `deploy-skills.ps1` — writes them **per-repo** and must be run manually against each repo. An old version of `sync-skills.ps1` used to push to the global `~/.claude/commands/`, but that global push was removed (the script now explicitly avoids it), so nothing lands skills machine-wide. Result: every new repo is skill-less until someone remembers to re-run the deploy.

## Approach

Defer to the mechanism Claude Code already provides: **user-level skills in `~/.claude/skills/`**, which are resolved in every project with zero per-repo replication. `deploy-skills.ps1` now hoists the **project-agnostic** subset into that directory.

- New `$globalSkills` set: `workflow-enforcer`, `code-quality`, `framework-first`, `branching-strategy`, `code-tutor-workflow`.
- New `Write-GlobalUserSkills` function copies each skill's canonical `.github/skills/<name>/SKILL.md` (frontmatter-style master) → `~/.claude/skills/<name>/SKILL.md`.
- New `-GlobalOnly` switch performs just the hoist (skips the per-repo loop); a normal full deploy also refreshes the global set so it never drifts.

## Why `forge-workflow` is excluded

`forge-workflow`'s master is hardcoded to Forge Terminal ("Forge Workflow Standards (Forge Terminal)", `go build ./cmd/forge/`, `cd frontend && npx vite build`, `autopilot_fleet`). Hoisting it would tell unrelated repos to build Forge's frontend. It stays project-local. `workflow-enforcer` has built-in project-mode detection (Phase 0A) and degrades to "Standard mode" in non-Forge repos, so the cascade stays coherent without `forge-workflow` present.

## Tradeoff considered

User-level skills **override** project-level ones (Claude Code precedence: enterprise > user > project). So in forge-terminal itself the hoisted skills now shadow its local `.claude/commands/` copies. This is acceptable — even desirable — because `.github/skills/` is already the canonical source `deploy-skills.ps1` distributes from, so this collapses the long-standing "same skill in 3 places, 3 different texts" drift rather than adding to it.

## Verification

- `deploy-skills.ps1 -GlobalOnly -DryRun` → parses, resolves 5 skills, writes nothing.
- `deploy-skills.ps1 -GlobalOnly` → 5 `SKILL.md` files written under `~/.claude/skills/` with valid `name`+`description` frontmatter (confirmed on disk).
- Pre-push gate green: `go build ./cmd/forge/`, `go test ./...`, frontend `vitest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)