### PR TITLE
fix: scaffolded pre-push hook builds whole module, not Forge's entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. created from the Projects card) started with no workflow skills at all.
 
 ### Fixed
+- **Scaffolded pre-push hooks build the whole module, not Forge's entrypoint**:
+  `forge workflow init` previously generated a pre-push hook hardcoded to
+  `go build ./cmd/forge/` (Forge Terminal's own entrypoint), so every other
+  scaffolded Go repo's hook false-failed on every push and forced
+  `git push --no-verify`. The `prePushSHTemplate` / `prePushPS1Template` in
+  `internal/workflow/templates.go` now build `go build ./...` (entrypoint-agnostic)
+  and regenerate `templ` output first — guarded on the `tool github.com/a-h/templ`
+  directive so it is a no-op in non-templ projects. Existing repos must re-scaffold
+  or update the hook by hand; new ones get the corrected hook automatically.
 - **Tab naming strategy now applied on startup**: On every app launch, Forge now
   fetches `/api/tab-defaults` after session restore and calls `retitleAllTabsFromCwd`
   with the server-authoritative strategy. Previously, `useTabNaming` read only from

--- a/internal/workflow/templates.go
+++ b/internal/workflow/templates.go
@@ -964,10 +964,19 @@ var prePushPS1Template = "#!/usr/bin/env pwsh\n" +
 	"\n" +
 	"# ── Go Build + Test ─────────────────────────────────────────────────────\n" +
 	"if (Test-Path \"go.mod\") {\n" +
+	"    # Projects using a-h/templ generate Go source from .templ files that are\n" +
+	"    # gitignored (*_templ.go); regenerate them first so a clean build does not fail.\n" +
+	"    # Guarded on the templ tool directive so this is a no-op in non-templ projects.\n" +
+	"    if (Select-String -Path go.mod -Pattern \"tool github.com/a-h/templ\" -Quiet) {\n" +
+	"        Write-Host \"  [Go] Generating templ files...\" -ForegroundColor Cyan\n" +
+	"        go tool templ generate *> $null\n" +
+	"    }\n" +
 	"    Write-Host \"  [Go] Building...\" -ForegroundColor Cyan\n" +
-	"    $buildOutput = go build ./cmd/forge/ 2>&1\n" +
+	"    # Build every package, not a single hardcoded entrypoint, so this hook stays\n" +
+	"    # correct regardless of the project's cmd/ layout.\n" +
+	"    $buildOutput = go build ./... 2>&1\n" +
 	"    if ($LASTEXITCODE -ne 0) {\n" +
-	"        $failures += \"GO BUILD: go build ./cmd/forge/ failed\"\n" +
+	"        $failures += \"GO BUILD: go build ./... failed\"\n" +
 	"        Write-Host \"  [Go] Build FAILED\" -ForegroundColor Red\n" +
 	"        Write-Host $buildOutput -ForegroundColor Red\n" +
 	"    } else {\n" +
@@ -1030,10 +1039,19 @@ var prePushSHTemplate = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"# ── Go Build + Test ─────────────────────────────────────────────────────\n" +
 	"if [[ -f \"go.mod\" ]]; then\n" +
+	"    # Projects using a-h/templ generate Go source from .templ files that are\n" +
+	"    # gitignored (*_templ.go); regenerate them first so a clean build does not fail.\n" +
+	"    # Guarded on the templ tool directive so this is a no-op in non-templ projects.\n" +
+	"    if grep -q \"tool github.com/a-h/templ\" go.mod 2>/dev/null; then\n" +
+	"        echo -e \"  \\033[36m[Go] Generating templ files...\\033[0m\"\n" +
+	"        go tool templ generate > /dev/null 2>&1\n" +
+	"    fi\n" +
 	"    echo -e \"  \\033[36m[Go] Building...\\033[0m\"\n" +
-	"    build_output=$(go build ./cmd/forge/ 2>&1)\n" +
+	"    # Build every package, not a single hardcoded entrypoint, so this hook stays\n" +
+	"    # correct regardless of the project's cmd/ layout.\n" +
+	"    build_output=$(go build ./... 2>&1)\n" +
 	"    if [[ $? -ne 0 ]]; then\n" +
-	"        failures+=(\"GO BUILD: go build ./cmd/forge/ failed\")\n" +
+	"        failures+=(\"GO BUILD: go build ./... failed\")\n" +
 	"        echo -e \"  \\033[31m[Go] Build FAILED\\033[0m\"\n" +
 	"        echo \"$build_output\"\n" +
 	"    else\n" +

--- a/internal/workflow/templates_prepush_test.go
+++ b/internal/workflow/templates_prepush_test.go
@@ -1,0 +1,56 @@
+// templates_prepush_test.go — verifies the generated pre-push hook builds every
+// package (entrypoint-agnostic) and regenerates templ output, so scaffolded repos
+// never inherit a hook hardcoded to Forge Terminal's own cmd/forge entrypoint.
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// prePushRenderers maps a human-readable hook name to its renderer, so each
+// assertion runs against both the Bash and PowerShell pre-push templates.
+var prePushRenderers = map[string]func(WorkflowConfig) (string, error){
+	"pre-push.ps1": RenderPrePushPS1,
+	"pre-push":     RenderPrePushSH,
+}
+
+// TestPrePushHooks_BuildEveryPackageNotForgeEntrypoint guards against the regression
+// where the scaffold emitted `go build ./cmd/forge/` into every repo's pre-push hook.
+// cmd/forge only exists in Forge Terminal itself, so the hook false-failed on every
+// other scaffolded project and forced `git push --no-verify`. The hook must build the
+// whole module with `go build ./...` instead.
+func TestPrePushHooks_BuildEveryPackageNotForgeEntrypoint(t *testing.T) {
+	for name, render := range prePushRenderers {
+		script, err := render(WorkflowConfig{})
+		if err != nil {
+			t.Fatalf("%s: render failed: %v", name, err)
+		}
+		if strings.Contains(script, "cmd/forge") {
+			t.Errorf("%s: hook still hardcodes Forge Terminal's entrypoint (cmd/forge); it must build ./...", name)
+		}
+		if !strings.Contains(script, "go build ./...") {
+			t.Errorf("%s: hook does not build every package with 'go build ./...'", name)
+		}
+	}
+}
+
+// TestPrePushHooks_RegenerateTemplBeforeBuild ensures the hook regenerates the
+// gitignored *_templ.go files before building — but only when the project actually
+// wires templ as a Go tool dependency. Without the guard, a non-templ project would
+// run a meaningless command; without the step, a clean checkout of a templ project
+// fails the build on missing generated source.
+func TestPrePushHooks_RegenerateTemplBeforeBuild(t *testing.T) {
+	for name, render := range prePushRenderers {
+		script, err := render(WorkflowConfig{})
+		if err != nil {
+			t.Fatalf("%s: render failed: %v", name, err)
+		}
+		if !strings.Contains(script, "go tool templ generate") {
+			t.Errorf("%s: hook does not regenerate templ output before building", name)
+		}
+		if !strings.Contains(script, "tool github.com/a-h/templ") {
+			t.Errorf("%s: templ regeneration is not guarded on the go.mod templ tool directive", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`forge workflow init` scaffolds a pre-push hook hardcoded to `go build ./cmd/forge/` — Forge Terminal's *own* entrypoint. In every other scaffolded Go repo that path doesn't exist, so the hook **false-fails on every push**, forcing developers to `git push --no-verify`. This is the upstream cause of the broken hook seen in the `linker` repo (fixed there by hand in linker PR #1). It also never ran `templ generate`, so repos using `a-h/templ` failed the build on the gitignored `*_templ.go`.

## Fix

`internal/workflow/templates.go` — `prePushSHTemplate` and `prePushPS1Template`:
- Build `go build ./...` (entrypoint-agnostic) instead of `./cmd/forge/`, so the hook can never again false-fail on a project's `cmd/` layout.
- Regenerate templ output before building, **guarded** on the `tool github.com/a-h/templ` go.mod directive so it's a no-op in non-templ projects.

## Tests

New `templates_prepush_test.go` (TDD — written failing first) asserts both rendered hooks: build `./...`, never reference `cmd/forge`, and include the guarded `go tool templ generate` step.

## Scope note

This ships in the `forge` binary, so it corrects hooks for **future** `forge workflow init` runs. Existing scaffolded repos keep their current hook and must re-scaffold or fix it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)