### PR TITLE
feat: global constitution install across all CLI tools (Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Global constitution install — every CLI tool inherits the rules** — New
+  `POST /api/workflow/global-install` writes the Forge constitution machine-wide:
+  a master copy at `~/.forge/constitution.md` plus an idempotent, marker-fenced
+  block (`<!-- FORGE-CONSTITUTION-START/END -->`) embedded into each supported
+  CLI tool's global instructions file — `~/.claude/CLAUDE.md`,
+  `~/.copilot/copilot-instructions.md`, and `~/.gemini/GEMINI.md`. Re-running
+  replaces the managed block in place and never touches the user's own
+  surrounding instructions. This is the cross-CLI hoist that lets every tool, in
+  every project, inherit the binding rules without per-project reconstruction.
+  Only the constitution is hoisted globally — the `speckit-*` skills stay
+  per-project because they depend on a project-local `.specify/` tree.
 - **Spec Kit pipeline vendored — forge-terminal is now a Spec Kit project** —
   The real GitHub Spec Kit payload (`specify` CLI v0.10.3) is vendored into the
   repo: ten `speckit-*` agent skills under `.claude/skills/` (constitution,

--- a/cmd/forge/handlers_workflow_global.go
+++ b/cmd/forge/handlers_workflow_global.go
@@ -1,0 +1,53 @@
+// Global workflow install endpoint — hoists the Forge constitution machine-wide
+// so every CLI tool (Claude, Copilot, Gemini), in every project, inherits the
+// project's binding rules without per-project reconstruction.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/mikejsmith1985/forge-terminal/internal/workflow"
+)
+
+// globalInstallProjectName labels the machine-wide constitution. It is generic
+// because this copy is the base every project inherits, not any single project's.
+const globalInstallProjectName = "Forge (global default)"
+
+// handleWorkflowGlobalInstall installs the Forge constitution into every
+// supported CLI tool's machine-wide instructions file. POST /api/workflow/global-install.
+func handleWorkflowGlobalInstall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		http.Error(w, "cannot resolve home directory: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Render the base constitution from the same template scaffolded projects use,
+	// so the global default and per-project copies share one source of truth.
+	config := workflow.DefaultConfig()
+	config.ProjectName = globalInstallProjectName
+	config.ProjectType = workflow.ProjectTypeGeneric
+	constitution, err := workflow.RenderConstitution(config)
+	if err != nil {
+		http.Error(w, "rendering constitution: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	result, err := workflow.InstallGlobalConstitution(homeDir, constitution)
+	if err != nil {
+		http.Error(w, "global install failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[Workflow] Global constitution installed to %d CLI tool(s)", len(result.TargetsWritten))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}

--- a/cmd/forge/handlers_workflow_global_test.go
+++ b/cmd/forge/handlers_workflow_global_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHandleWorkflowGlobalInstall_RejectsNonPost proves the endpoint only
+// accepts POST — a GET must not trigger any filesystem writes.
+func TestHandleWorkflowGlobalInstall_RejectsNonPost(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/api/workflow/global-install", nil)
+	recorder := httptest.NewRecorder()
+
+	handleWorkflowGlobalInstall(recorder, request)
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", recorder.Code)
+	}
+}
+
+// TestHandleWorkflowGlobalInstall_WritesToHome proves a POST renders the real
+// constitution and installs it into each CLI tool's global file. HOME and
+// USERPROFILE are redirected to a temp dir so the test never touches the real
+// home directory (USERPROFILE is what os.UserHomeDir reads on Windows; HOME on
+// Unix — set both for cross-platform safety).
+func TestHandleWorkflowGlobalInstall_WritesToHome(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("USERPROFILE", tempHome)
+	t.Setenv("HOME", tempHome)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/workflow/global-install", nil)
+	recorder := httptest.NewRecorder()
+
+	handleWorkflowGlobalInstall(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", recorder.Code, recorder.Body.String())
+	}
+
+	var result struct {
+		MasterPath     string   `json:"masterPath"`
+		TargetsWritten []string `json:"targetsWritten"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(result.TargetsWritten) != 3 {
+		t.Errorf("expected 3 CLI targets written, got %d", len(result.TargetsWritten))
+	}
+
+	// The Claude global file should exist and carry the real constitution.
+	claudeFile := filepath.Join(tempHome, ".claude", "CLAUDE.md")
+	content, err := os.ReadFile(claudeFile)
+	if err != nil {
+		t.Fatalf("Claude global file not written: %v", err)
+	}
+	if !strings.Contains(string(content), "fterm.exe") {
+		t.Error("installed constitution missing process-protection rule")
+	}
+}

--- a/cmd/forge/main.go
+++ b/cmd/forge/main.go
@@ -609,6 +609,7 @@ func main() {
 	http.HandleFunc("/api/workflow/status", WrapWithMiddleware(handleWorkflowStatus))
 	http.HandleFunc("/api/workflow/compliance", WrapWithMiddleware(handleWorkflowCompliance))
 	http.HandleFunc("/api/workflow/modules", WrapWithMiddleware(handleWorkflowModules))
+	http.HandleFunc("/api/workflow/global-install", WrapWithMiddleware(handleWorkflowGlobalInstall))
 	http.HandleFunc("/api/workflow/release-preflight", WrapWithMiddleware(handleReleasePreflight))
 	http.HandleFunc("/api/workflow/watch", WrapWithMiddleware(handleWorkflowWatchStart))
 	http.HandleFunc("/api/workflow/watch/poll", WrapWithMiddleware(handleWorkflowWatchPoll))

--- a/internal/workflow/global_install.go
+++ b/internal/workflow/global_install.go
@@ -1,0 +1,117 @@
+// Global install writes the Forge constitution machine-wide so every CLI tool,
+// in every project, inherits the project's binding rules without per-project
+// reconstruction. This is the cross-CLI hoist for Spec-Driven Development: the
+// constitution is self-contained markdown (unlike the speckit-* skills, which
+// depend on a per-project .specify/ tree), so it is the one artifact that is
+// safe to install once at the user level.
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Marker fences delimit the Forge-managed block inside each CLI tool's global
+// instructions file. Content outside the fence is the user's own — never touched.
+const (
+	constitutionMarkerStart = "<!-- FORGE-CONSTITUTION-START -->"
+	constitutionMarkerEnd   = "<!-- FORGE-CONSTITUTION-END -->"
+)
+
+// GlobalInstallResult reports what the global constitution install wrote, so the
+// caller (and the user) can see exactly which CLI tools were updated.
+type GlobalInstallResult struct {
+	MasterPath     string   `json:"masterPath"`
+	TargetsWritten []string `json:"targetsWritten"`
+}
+
+// globalCLITarget describes one CLI tool's machine-wide instructions file —
+// the file that tool reads at the start of every session, in every project.
+type globalCLITarget struct {
+	name    string
+	relPath []string // path segments under the home directory
+}
+
+// globalCLITargets lists the supported CLI tools' global instruction files.
+// Verified machine-wide locations: Claude Code reads ~/.claude/CLAUDE.md,
+// GitHub Copilot CLI reads ~/.copilot/copilot-instructions.md, and Gemini CLI
+// reads ~/.gemini/GEMINI.md.
+func globalCLITargets() []globalCLITarget {
+	return []globalCLITarget{
+		{name: "claude", relPath: []string{".claude", "CLAUDE.md"}},
+		{name: "copilot", relPath: []string{".copilot", "copilot-instructions.md"}},
+		{name: "gemini", relPath: []string{".gemini", "GEMINI.md"}},
+	}
+}
+
+// InstallGlobalConstitution writes the constitution to a master copy under
+// ~/.forge and embeds it as an idempotent marker block into every supported CLI
+// tool's global instructions file. homeDir is passed in (not resolved here) so
+// the logic is unit-testable against a temporary directory.
+func InstallGlobalConstitution(homeDir, constitution string) (GlobalInstallResult, error) {
+	result := GlobalInstallResult{}
+
+	// 1. Write the canonical master copy the user can edit and tools can reference.
+	masterPath := filepath.Join(homeDir, ".forge", "constitution.md")
+	if err := writeFileEnsuringDir(masterPath, constitution); err != nil {
+		return result, fmt.Errorf("writing master constitution: %w", err)
+	}
+	result.MasterPath = masterPath
+
+	// 2. Embed the constitution into each CLI tool's global instructions file,
+	//    preserving any instructions the user already has there.
+	blockBody := constitution
+	for _, target := range globalCLITargets() {
+		segments := append([]string{homeDir}, target.relPath...)
+		targetPath := filepath.Join(segments...)
+
+		existing := ""
+		if data, err := os.ReadFile(targetPath); err == nil {
+			existing = string(data)
+		}
+
+		updated := upsertMarkerBlock(existing, blockBody, constitutionMarkerStart, constitutionMarkerEnd)
+		if err := writeFileEnsuringDir(targetPath, updated); err != nil {
+			return result, fmt.Errorf("writing %s global instructions: %w", target.name, err)
+		}
+		result.TargetsWritten = append(result.TargetsWritten, targetPath)
+	}
+
+	return result, nil
+}
+
+// upsertMarkerBlock inserts or replaces the Forge-managed block (the text between
+// startMarker and endMarker) with blockBody, leaving all content outside the
+// markers untouched. When the markers are absent it appends a fresh block. This
+// is what makes re-running the installer safe — the user's own instructions are
+// never clobbered, and the managed block never stacks duplicates.
+func upsertMarkerBlock(existingContent, blockBody, startMarker, endMarker string) string {
+	managedBlock := startMarker + "\n" + blockBody + "\n" + endMarker
+
+	startIndex := strings.Index(existingContent, startMarker)
+	endIndex := strings.Index(existingContent, endMarker)
+
+	// Replace in place when a well-formed existing block is present.
+	if startIndex != -1 && endIndex != -1 && endIndex > startIndex {
+		before := existingContent[:startIndex]
+		after := existingContent[endIndex+len(endMarker):]
+		return before + managedBlock + after
+	}
+
+	// No existing block: append, separating from any prior content with a blank line.
+	if strings.TrimSpace(existingContent) == "" {
+		return managedBlock + "\n"
+	}
+	return strings.TrimRight(existingContent, "\n") + "\n\n" + managedBlock + "\n"
+}
+
+// writeFileEnsuringDir creates the parent directory if needed, then writes the
+// file. Centralizes the MkdirAll + WriteFile pattern used across the installer.
+func writeFileEnsuringDir(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/workflow/global_install_test.go
+++ b/internal/workflow/global_install_test.go
@@ -1,0 +1,118 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeConstitution is a stand-in body used to prove the install/upsert logic
+// without depending on the real template content.
+const fakeConstitution = "# Global Constitution\n\nProcess protection: never wildcard-kill fterm.exe.\n"
+
+// TestInstallGlobalConstitution_FreshHome proves a first-time install writes the
+// master copy plus every supported CLI tool's global instructions file.
+func TestInstallGlobalConstitution_FreshHome(t *testing.T) {
+	homeDir := t.TempDir()
+
+	result, err := InstallGlobalConstitution(homeDir, fakeConstitution)
+	if err != nil {
+		t.Fatalf("InstallGlobalConstitution() error: %v", err)
+	}
+
+	// Master copy under ~/.forge
+	masterPath := filepath.Join(homeDir, ".forge", "constitution.md")
+	masterBytes, err := os.ReadFile(masterPath)
+	if err != nil {
+		t.Fatalf("master constitution not written: %v", err)
+	}
+	if string(masterBytes) != fakeConstitution {
+		t.Error("master constitution content does not match input")
+	}
+
+	// Each CLI tool's global file must exist, carry both markers, and embed the body.
+	cliFiles := map[string]string{
+		"claude":  filepath.Join(homeDir, ".claude", "CLAUDE.md"),
+		"copilot": filepath.Join(homeDir, ".copilot", "copilot-instructions.md"),
+		"gemini":  filepath.Join(homeDir, ".gemini", "GEMINI.md"),
+	}
+	for tool, path := range cliFiles {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s global file not written: %v", tool, err)
+			continue
+		}
+		text := string(content)
+		if !strings.Contains(text, constitutionMarkerStart) || !strings.Contains(text, constitutionMarkerEnd) {
+			t.Errorf("%s global file missing constitution markers", tool)
+		}
+		if !strings.Contains(text, "fterm.exe") {
+			t.Errorf("%s global file missing constitution body", tool)
+		}
+	}
+
+	if len(result.TargetsWritten) != len(cliFiles) {
+		t.Errorf("expected %d targets written, got %d", len(cliFiles), len(result.TargetsWritten))
+	}
+}
+
+// TestInstallGlobalConstitution_Idempotent proves re-installing does not stack
+// duplicate marker blocks — the managed block is replaced, not appended.
+func TestInstallGlobalConstitution_Idempotent(t *testing.T) {
+	homeDir := t.TempDir()
+
+	if _, err := InstallGlobalConstitution(homeDir, fakeConstitution); err != nil {
+		t.Fatalf("first install error: %v", err)
+	}
+	if _, err := InstallGlobalConstitution(homeDir, fakeConstitution); err != nil {
+		t.Fatalf("second install error: %v", err)
+	}
+
+	claudePath := filepath.Join(homeDir, ".claude", "CLAUDE.md")
+	content, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(string(content), constitutionMarkerStart); count != 1 {
+		t.Errorf("expected exactly 1 constitution block after re-install, found %d", count)
+	}
+}
+
+// TestUpsertMarkerBlock_PreservesUserContent proves the user's own instructions
+// outside the managed markers survive an update.
+func TestUpsertMarkerBlock_PreservesUserContent(t *testing.T) {
+	existing := "# My personal notes\n\n" +
+		constitutionMarkerStart + "\nOLD BODY\n" + constitutionMarkerEnd +
+		"\n\n# More personal notes\n"
+
+	updated := upsertMarkerBlock(existing, "NEW BODY", constitutionMarkerStart, constitutionMarkerEnd)
+
+	if !strings.Contains(updated, "# My personal notes") || !strings.Contains(updated, "# More personal notes") {
+		t.Error("user content outside markers was lost")
+	}
+	if strings.Contains(updated, "OLD BODY") {
+		t.Error("old managed body was not replaced")
+	}
+	if !strings.Contains(updated, "NEW BODY") {
+		t.Error("new managed body was not inserted")
+	}
+	if count := strings.Count(updated, constitutionMarkerStart); count != 1 {
+		t.Errorf("expected 1 marker block, found %d", count)
+	}
+}
+
+// TestUpsertMarkerBlock_AppendsWhenAbsent proves the block is appended (not
+// dropped) when the file has no existing markers.
+func TestUpsertMarkerBlock_AppendsWhenAbsent(t *testing.T) {
+	existing := "# Existing user instructions\n"
+
+	updated := upsertMarkerBlock(existing, "BODY", constitutionMarkerStart, constitutionMarkerEnd)
+
+	if !strings.Contains(updated, "# Existing user instructions") {
+		t.Error("existing content was lost")
+	}
+	if !strings.Contains(updated, constitutionMarkerStart) || !strings.Contains(updated, "BODY") {
+		t.Error("managed block was not appended")
+	}
+}


### PR DESCRIPTION
## What & Why

Phase B, **PR #1** of re-orchestrating the Forge workflow around GitHub Spec Kit. This is the slice that reaches your original goal — **stop reconstructing base requirements in every project, for every CLI tool**.

New `POST /api/workflow/global-install` writes the Forge constitution **machine-wide**:
- `~/.forge/constitution.md` — canonical master copy
- `~/.claude/CLAUDE.md`, `~/.copilot/copilot-instructions.md`, `~/.gemini/GEMINI.md` — each gets the constitution embedded in an idempotent, marker-fenced block (`<!-- FORGE-CONSTITUTION-START/END -->`)

Re-running replaces the managed block **in place** — the user's own surrounding instructions are never touched (same marker discipline as Forge's existing `FORGE-SKILLS` blocks).

## Key design decisions

- **Constitution only — not the speckit skills.** The `speckit-*` skills reference a project-local `.specify/` tree; hoisted into `~/.claude/skills` they'd point at scripts that don't exist in arbitrary projects. The constitution is self-contained markdown, so it's the one artifact safe to install once at the user level. Per-project speckit provisioning is a separate slice.
- **Testable by construction.** `InstallGlobalConstitution(homeDir, constitution)` takes the home dir as a parameter, so the core logic is unit-tested against a temp dir with **zero writes to the real `~/`**. The handler test redirects `HOME`/`USERPROFILE` to a temp dir for the same safety.
- **Reuses existing conventions** from `handlers_cli_config.go` (`os.UserHomeDir`, `MkdirAll 0755`, `WriteFile 0644`) rather than inventing new ones.

## Files
| File | Role |
|---|---|
| `internal/workflow/global_install.go` | Core: master + per-CLI marker-block upsert (home dir injected) |
| `internal/workflow/global_install_test.go` | 4 tests: fresh install, idempotent re-install, upsert preserves user content (markers present/absent) |
| `cmd/forge/handlers_workflow_global.go` | `POST /api/workflow/global-install` handler |
| `cmd/forge/handlers_workflow_global_test.go` | 2 tests: 405 on GET, 200 + 3 files on POST (temp HOME) |
| `cmd/forge/main.go` | Route registration |

## Verification
- `go build ./cmd/forge/` clean; `go vet` clean; all 6 new tests green alongside the existing suite.
- Real-output proof (throwaway test, since removed): confirmed the constitution lands in all three CLI files wrapped in the markers, with the actual Articles (process protection, GitHub-Actions ban, vault, etc.).

## Next (not in this PR)
- Wire `speckit-*` into the scaffold engine so **child projects** get the pipeline (per-project, not global).
- Extend `deploy-skills.ps1 -GlobalOnly` to call this endpoint / mirror it.
- A UI affordance to trigger the global install.
- **Phase C** (destructive): dissolve `forge-workflow`, retire the monolith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)