### PR TITLE
chore: constitution superset audit (SDD Phase C gate)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -26,8 +26,9 @@ Branch names are lowercase, hyphenated, and descriptive — scoped to one concer
 
 Names must be self-documenting: no single-letter variables (except `i`/`j`/`k` loop iterators
 and `w`/`r` HTTP handler parameters). Booleans are prefixed `is`/`has`/`can`/`should`/`was`.
-Functions are verb-first. No magic numbers. Comments explain the "why," readable by a non-developer.
-Functions stay under 40 lines; prefer guard clauses over deep nesting.
+Functions are verb-first. No magic numbers. Comments explain the "why," readable by a non-developer:
+every file opens with a one-line purpose comment, and every exported/public function carries a doc
+comment. Functions stay under 40 lines; prefer guard clauses over deep nesting.
 
 ## Article V — Testing (Three-Layer Separation)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Constitution now a proven superset of the legacy rules (SDD Phase C gate)** —
+  Audited the 1124-line `copilot-instructions.md` monolith against the constitution's
+  Articles ahead of retiring it. One gap was found and closed: Article IV (Code
+  Quality) now states the explicit comment mandate — every file opens with a
+  one-line purpose comment and every exported function carries a doc comment —
+  matching the monolith. forge-terminal's own `.specify/memory/constitution.md` was
+  regenerated from the template so the two stay byte-identical. This makes the
+  constitution safe to use as the single source of truth when the monolith is
+  dissolved.
+
 ### Added
 - **"Install Constitution Globally" button** — The Forge Workflow sidebar card now
   has a one-click action to install the constitution machine-wide (calling

--- a/internal/workflow/templates.go
+++ b/internal/workflow/templates.go
@@ -1194,8 +1194,9 @@ Branch names are lowercase, hyphenated, and descriptive — scoped to one concer
 
 Names must be self-documenting: no single-letter variables (except ` + "`i`/`j`/`k`" + ` loop iterators
 and ` + "`w`/`r`" + ` HTTP handler parameters). Booleans are prefixed ` + "`is`/`has`/`can`/`should`/`was`" + `.
-Functions are verb-first. No magic numbers. Comments explain the "why," readable by a non-developer.
-Functions stay under 40 lines; prefer guard clauses over deep nesting.
+Functions are verb-first. No magic numbers. Comments explain the "why," readable by a non-developer:
+every file opens with a one-line purpose comment, and every exported/public function carries a doc
+comment. Functions stay under 40 lines; prefer guard clauses over deep nesting.
 
 ## Article V — Testing (Three-Layer Separation)
 


### PR DESCRIPTION
## What & Why

**Phase C, step C0** — the prerequisite gate before the destructive steps that retire the `copilot-instructions.md` monolith. Before deleting anything, prove the constitution captures every binding rule the monolith carries.

Audited the 1124-line monolith against the 11 Articles. It was already a faithful superset except **one gap**: the explicit comment mandate. Article IV now states it — *every file opens with a one-line purpose comment, every exported function carries a doc comment* — matching the monolith.

## Changes
- `templates.go` — enrich Article IV in `constitutionTemplate`.
- `.specify/memory/constitution.md` — regenerated from the template (throwaway generator test, since removed) so the repo's own constitution stays byte-identical to scaffolded projects'.

## Audit decision recorded
The GitHub-issue-images workflow (monolith §7) is **not** constitutionalized — it's a Copilot tool-capability instruction, not a universal principle. It stays runtime-specific in the slim `copilot-instructions.md` when the monolith is dissolved (C3).

## Verification
- `go test ./internal/workflow/` green (incl. `TestRenderConstitution_IncludesAllArticles`); `go build ./cmd/forge/` clean.
- Confirmed the new mandate is present in both the template output and the committed repo constitution.

**Non-destructive** — nothing removed. This makes the constitution a *provable* superset so Phase C's destructive steps (C1 re-point enforcer → C2 collapse skills → C3 retire monolith) can proceed safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)