### PR TITLE
chore: workflow-enforcer is constitution- & Spec-Kit-aware (Phase C1)

### DIFF
--- a/.claude/commands/workflow-enforcer.md
+++ b/.claude/commands/workflow-enforcer.md
@@ -1,32 +1,255 @@
-# Workflow Enforcer — Circuit Breaker
+# Workflow Enforcer
 
-You have invoked the Forge Workflow circuit breaker. This skill is the gatekeeper for ALL code changes in this repository. Read every word before proceeding.
+> ⚠️ This skill is MANDATORY. It applies to EVERY coding task in every project.
+> However, it adapts its requirements based on whether the project uses the
+> full Forge Forge Workflow or a standard workflow.
 
-## What you MUST do right now (in this order)
 
-1. **Invoke `forge-workflow`** — loads the 5-Phase execution plan you will follow for this task
-2. **Invoke `code-quality`** — loads naming conventions and comment standards that apply to every line you write
-3. **Invoke `framework-first`** — the architecture-fidelity gate: before building any infrastructure, confirm the project's framework does not already provide it
-4. **Invoke `branching-strategy`** — enforces branch creation before the first file edit
-5. **Invoke `code-tutor-workflow`** — user expects a clear walkthrough of every change you make
+## PHASE 0A: PROJECT DETECTION (Run First — Before Any Co-Skills)
 
-Do not read any files, write any code, or run any commands until all five companion skills are loaded.
+Before loading any co-skills, determine the **project mode** by checking two things:
 
-## Hard rules that apply after skills are loaded
+**Check 1 — Does `AGENTS.md` exist in the repository root?**
+```powershell
+Test-Path "AGENTS.md"
+```
 
-- **Branch before code.** If `git branch --show-current` outputs `main`, STOP. You have not created your branch yet.
-- **Phase 1 before Phase 3.** You must articulate a plan before touching any source file.
-- **No shortcuts.** "It compiles" is not proof. "The test passes" is not proof unless it is a real integration test against real infrastructure.
-- **Never kill forge by wildcard.** The production binary is `fterm.exe`. Use `Stop-Process -Id <PID>` with a specific PID only.
-- **Phase 5 is mandatory.** Every task ends with: CHANGELOG entry → commit → `gh pr create` → merge → `.\scripts\local-release.ps1`.
+**Check 2 — Does `.github/skills/forge-workflow/` exist?**
+```powershell
+Test-Path ".github/skills/forge-workflow"
+```
 
-## If you skipped this skill
+**Check 3 — Does `.specify/memory/constitution.md` exist?**
+```powershell
+Test-Path ".specify/memory/constitution.md"
+```
+If present, the project is in **Spec-Driven Development (SDD) mode**. The constitution at
+`.specify/memory/constitution.md` is the AUTHORITATIVE source of binding rules — read it FIRST,
+before any co-skill. Its Articles supersede any duplicated standards elsewhere.
 
-If you are reading this after already writing code:
+### Mode Decision Table
 
-1. STOP immediately
-2. Tell the user you violated pre-flight
-3. Ask whether to revert and restart, or course-correct in place
-4. Do not rationalize or continue
+| AGENTS.md | forge-workflow skill | Detected Mode |
+|-----------|----------------------|---------------|
+| ✅ Found  | ✅ Found             | **Forge Enterprise** |
+| ❌ Missing | ✅ Found             | **Enterprise** |
+| ❌ Missing | ❌ Missing           | **Standard** |
 
-The pre-flight sequence exists because the failure mode is: analyze → plan → code → *remember skills too late*. This rule breaks that pattern.
+Store the detected mode. It controls which co-skills are **required** vs **optional**. SDD mode (Check 3)
+overlays the detected mode: when a constitution is present, its Articles are the binding rules and the
+`speckit-*` pipeline (Phase 0B) is the workflow.
+
+
+## PHASE 0B: CO-SKILL CASCADE
+
+Invoke co-skills in the order listed. Behavior on failure differs by mode:
+
+### Always Required (all modes)
+These must load successfully in every project. If missing, report ❌ and stop.
+```
+invoke skill: code-quality
+invoke skill: framework-first
+```
+
+### Spec-Driven Development pipeline (load when `.specify/` exists)
+When the project has a `.specify/` directory, the GitHub Spec Kit pipeline IS the workflow. Use the
+`speckit-*` skills to drive execution, reading `.specify/memory/constitution.md` as the binding rules:
+```
+speckit-specify  →  speckit-plan  →  speckit-tasks  →  speckit-implement
+```
+Quality gates (load as the task warrants): `speckit-clarify` (de-risk before plan),
+`speckit-analyze` (cross-artifact consistency before implement), `speckit-checklist`.
+
+### Forge Terminal Project Only (load when AGENTS.md is present)
+These skills are specific to the Forge Terminal codebase. Load them automatically
+when `AGENTS.md` exists — they teach the agent about project-specific systems.
+If a skill is missing, report ⚠️ and continue.
+```
+invoke skill: forge-vault
+invoke skill: sequential-tasks
+```
+
+### Enterprise-Only (required in Forge Enterprise / Enterprise mode; optional in Standard)
+Attempt to load these in every project. If the project is in **Standard mode** and
+a skill is not found, mark it ⚠️ and continue — do NOT block the task.
+If the project is in **Enterprise mode** and a skill is not found, mark it ❌ and stop.
+```
+invoke skill: forge-workflow         # superseded by the constitution + speckit pipeline; retained until Phase C3
+invoke skill: branching-strategy
+invoke skill: code-tutor-workflow
+```
+
+### Conditionally Required (invoke when the task warrants it)
+```
+invoke skill: multi-agent             # tasks spanning 3+ files
+invoke skill: testing-standards       # test creation or modification
+invoke skill: pr-workflow             # PR creation or review
+invoke skill: forge-release-process   # release, publish, bump version, create a release
+invoke skill: add-command-card        # create command card, launch POC, add sidebar shortcut
+```
+
+
+## PHASE 0C: PRE-FLIGHT STATUS TABLE
+
+After attempting all loads, output the following table. The `AGENTS.md` row
+reflects the Check 1 result from Phase 0A.
+
+```
+⛳ PRE-FLIGHT COMPLETE
+
+┌─────────────────────────┬────────────────────────────────────────────┐
+│ Item                    │ Status                                     │
+├─────────────────────────┼────────────────────────────────────────────┤
+│ code-quality            │ ✅ Loaded                                  │
+│ forge-vault             │ ✅ Loaded  /  ⚠️ Not configured (optional)  │
+│ sequential-tasks        │ ✅ Loaded  /  ⚠️ Not configured (optional)  │
+│ forge-workflow          │ ✅ Loaded  /  ⚠️ Not configured (optional) /  ❌ Required but missing │
+│ branching-strategy      │ ✅ Loaded  /  ⚠️ Not configured (optional) /  ❌ Required but missing │
+│ code-tutor-workflow     │ ✅ Loaded  /  ⚠️ Not configured (optional) /  ❌ Required but missing │
+│ AGENTS.md               │ ✅ Found   /  ⚠️ Not present (standard mode) │
+├─────────────────────────┼────────────────────────────────────────────┤
+│ Active mode             │ Forge Enterprise  /  Enterprise  /  Standard │
+│ Quality mode            │ BEST (enterprise)  /  FAST (standard)      │
+│ Audit focus             │ naming · complexity · comments             │
+└─────────────────────────┴────────────────────────────────────────────┘
+```
+
+Use only the applicable status value for each row — do not show all three options.
+
+### Status key
+- ✅ **Loaded / Found** — skill or file is present and active
+- ⚠️ **Not configured (optional)** — skill is absent but the project is in Standard mode; enforcement continues without it
+- ❌ **Required but missing** — skill is absent in a project that requires it; STOP and notify the user
+
+
+## PHASE 0D: BRANCH CHECK
+
+After the status table, confirm a feature branch exists:
+
+```powershell
+git branch --show-current
+```
+
+If the output is `main` or `master`: create a branch before writing any code.
+
+```powershell
+git checkout -b fix/<descriptive-name>      # bug fixes
+git checkout -b feature/<descriptive-name>  # new functionality
+git checkout -b chore/<descriptive-name>    # maintenance / cleanup
+git checkout -b docs/<descriptive-name>     # documentation only
+```
+
+**Only after the branch is confirmed: proceed to Phase 1.**
+
+
+## PHASE 1: WHILE CODING (Active Standards)
+
+These apply in all modes. Adjust strictness based on quality mode:
+- **BEST mode (Enterprise)**: zero tolerance — every rule is enforced
+- **FAST mode (Standard)**: best-effort — flag violations but don't block delivery
+
+### Naming
+- No single-letter variables (except `i`/`j`/`k` in loops, `w`/`r` in HTTP handlers)
+- All booleans prefixed with `is`, `has`, `can`, `should`, or `was`
+- All functions are verb-first: `createSession`, `validateToken`
+- A non-developer can understand every name without context
+
+### Comments
+- New files get a top-level purpose comment
+- Exported/public functions get a doc comment
+- Complex logic blocks get "why" comments, not "what" comments
+- Comments are readable by a technical project manager
+
+### Structure
+- No function exceeds 40 lines — extract helpers if needed
+- Guard clauses instead of deep nesting
+- No magic numbers or strings — use named constants
+- Imports are logically grouped
+
+
+## PHASE 2: PRE-DELIVERY CHECKLIST
+
+### ✅ Always check (all modes)
+- [ ] On a feature branch (not `main` / `master`) — `git branch --show-current`
+- [ ] Tests written or updated for changed code
+- [ ] Commit message follows format: `type(scope): description`
+
+### ✅ Check when CHANGELOG.md exists in the project
+- [ ] CHANGELOG.md updated if user-visible behavior changed
+
+### ✅ Enterprise mode only
+- [ ] Sub-agents used for parallelizable work (3+ independent files)
+- [ ] Task classified and appropriate model tier selected
+
+### ✅ Build and test — use the project's own commands
+Do NOT hardcode build or test commands. Discover them from:
+- `package.json` scripts → use `npm run build`, `npm test`
+- `Makefile` → use `make build`, `make test`
+- `go.mod` → use `go build ./...`, `go test ./...`
+- CI config (`.github/workflows/`) → mirror what CI runs
+
+If this is the **Forge Terminal** project specifically:
+- Go build: `go build ./cmd/forge/`
+- Frontend build: `cd frontend && npx vite build`
+- Go tests: `go test ./...`
+- Frontend tests: `cd frontend && npx vitest run`
+
+
+## PHASE 3: RUNTIME GATE LEDGER (HARD ENFORCEMENT)
+
+Skills alone cannot stop a non-compliant commit — only runtime hooks can.
+Forge Terminal ships a pre-commit hook that reads `.forge/workflow-ticket.json`
+and BLOCKS any commit whose ledger is missing a required gate.
+
+**Required gates the hook checks:**
+- `branch-created` — proves a feature branch was created before code
+- `tests-written` — proves at least one test was added or updated
+- `tests-passed` — proves the test run succeeded
+
+**Record gates as you complete them via the MCP tool:**
+```
+workflow_gate_record({
+  taskId:   "<stable id for this task>",
+  gate:     "branch-created" | "tests-written" | "tests-passed" | ...,
+  evidence: "<short proof, e.g. 'feature/foo created at HEAD ac04dbc'>",
+  branch:   "<branch name, optional>"
+})
+```
+
+**Verify the hook will allow your commit before running git:**
+```
+workflow_preflight_check()
+```
+or shell-equivalent:
+```
+forge workflow preflight
+```
+
+**One-time install of the hook in any new repo:**
+The hook is **installed automatically** the first time `workflow_gate_record` is called
+in a project (i.e., when the very first ticket is created).  No manual step is required.
+
+If for any reason you need to force-reinstall or install without recording a gate:
+```powershell
+.\scripts\install-workflow-hooks.ps1   # Windows
+./scripts/install-workflow-hooks.sh    # macOS / Linux
+```
+
+**Bypass (last resort, audited):** set `FORGE_BYPASS=1` and
+`FORGE_BYPASS_REASON="..."` in the environment for one commit.  Bypasses
+are appended to `.forge/bypasses.log` so reviewers can spot abuse.
+
+
+## ENFORCEMENT
+
+### Enterprise mode
+All Phase 2 items are hard requirements. If any are unchecked before delivery:
+1. STOP
+2. Fix the violation
+3. Re-verify the full checklist
+4. Only then deliver
+
+### Standard mode
+Phase 2 items are best-practice reminders. Flag any unchecked items in your
+delivery summary, but do not block the user from receiving the result.
+

--- a/.github/skills/workflow-enforcer/SKILL.md
+++ b/.github/skills/workflow-enforcer/SKILL.md
@@ -25,6 +25,14 @@ Test-Path "AGENTS.md"
 Test-Path ".github/skills/forge-workflow"
 ```
 
+**Check 3 — Does `.specify/memory/constitution.md` exist?**
+```powershell
+Test-Path ".specify/memory/constitution.md"
+```
+If present, the project is in **Spec-Driven Development (SDD) mode**. The constitution at
+`.specify/memory/constitution.md` is the AUTHORITATIVE source of binding rules — read it FIRST,
+before any co-skill. Its Articles supersede any duplicated standards elsewhere.
+
 ### Mode Decision Table
 
 | AGENTS.md | forge-workflow skill | Detected Mode |
@@ -33,7 +41,9 @@ Test-Path ".github/skills/forge-workflow"
 | ❌ Missing | ✅ Found             | **Enterprise** |
 | ❌ Missing | ❌ Missing           | **Standard** |
 
-Store the detected mode. It controls which co-skills are **required** vs **optional**.
+Store the detected mode. It controls which co-skills are **required** vs **optional**. SDD mode (Check 3)
+overlays the detected mode: when a constitution is present, its Articles are the binding rules and the
+`speckit-*` pipeline (Phase 0B) is the workflow.
 
 ---
 
@@ -47,6 +57,15 @@ These must load successfully in every project. If missing, report ❌ and stop.
 invoke skill: code-quality
 invoke skill: framework-first
 ```
+
+### Spec-Driven Development pipeline (load when `.specify/` exists)
+When the project has a `.specify/` directory, the GitHub Spec Kit pipeline IS the workflow. Use the
+`speckit-*` skills to drive execution, reading `.specify/memory/constitution.md` as the binding rules:
+```
+speckit-specify  →  speckit-plan  →  speckit-tasks  →  speckit-implement
+```
+Quality gates (load as the task warrants): `speckit-clarify` (de-risk before plan),
+`speckit-analyze` (cross-artifact consistency before implement), `speckit-checklist`.
 
 ### Forge Terminal Project Only (load when AGENTS.md is present)
 These skills are specific to the Forge Terminal codebase. Load them automatically
@@ -62,7 +81,7 @@ Attempt to load these in every project. If the project is in **Standard mode** a
 a skill is not found, mark it ⚠️ and continue — do NOT block the task.
 If the project is in **Enterprise mode** and a skill is not found, mark it ❌ and stop.
 ```
-invoke skill: forge-workflow
+invoke skill: forge-workflow         # superseded by the constitution + speckit pipeline; retained until Phase C3
 invoke skill: branching-strategy
 invoke skill: code-tutor-workflow
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`workflow-enforcer` is now constitution- and Spec-Kit-aware (SDD Phase C1)** —
+  The circuit-breaker skill detects `.specify/memory/constitution.md` (a new Phase 0A
+  check) and treats it as the authoritative source of binding rules, and names the
+  `speckit-*` pipeline (`specify → plan → tasks → implement`) as the workflow when a
+  `.specify/` directory is present. `forge-workflow` is annotated as superseded but
+  still loads (removed in C3). Also reconciles a three-way drift: the canonical
+  `.github/skills/workflow-enforcer/SKILL.md` and the derived
+  `.claude/commands/workflow-enforcer.md` had diverged into different content; the
+  command copy is now regenerated from the canonical so they match. (Machine-wide
+  `~/.claude/skills` propagation via `deploy-skills.ps1 -GlobalOnly` follows once the
+  skill-set collapse in C2 lands.)
 - **Constitution now a proven superset of the legacy rules (SDD Phase C gate)** —
   Audited the 1124-line `copilot-instructions.md` monolith against the constitution's
   Articles ahead of retiring it. One gap was found and closed: Article IV (Code


### PR DESCRIPTION
## What & Why

**Phase C, step C1.** Re-points the `workflow-enforcer` circuit breaker at the SDD pipeline — **non-destructively** (the legacy `forge-workflow` path still loads).

- **Phase 0A** gains `Check 3` for `.specify/memory/constitution.md` → "SDD mode": the constitution becomes the authoritative source of binding rules, read first.
- **Phase 0B** gains a Spec-Driven Development subsection naming the `speckit-*` pipeline (`specify → plan → tasks → implement`, with `clarify`/`analyze`/`checklist` gates) as the workflow when `.specify/` exists.
- `forge-workflow` is annotated *"superseded … retained until Phase C3"* but still loads.

## Drift reconciliation (the finding that reshaped C1)

`workflow-enforcer` existed in **three diverged copies**. This PR collapses the two in-repo copies: the derived `.claude/commands/workflow-enforcer.md` is regenerated from the canonical `.github/skills/workflow-enforcer/SKILL.md` (frontmatter stripped) so they're identical again. The machine-wide `~/.claude/skills` copy is refreshed via `deploy-skills.ps1 -GlobalOnly` **after C2 lands** (so the final state propagates once) — a `-DryRun` confirmed it touches only the 5 agnostic skills, **no sibling-repo writes**.

## Verification
- Confirmed `.claude/commands/workflow-enforcer.md` body == canonical (sans frontmatter); both carry the SDD additions.
- `-GlobalOnly -DryRun` clean (5 skills hoisted, dry).
- Non-destructive: `forge-workflow` still loads; pre-flight cascade unchanged in structure.

## Next
- **C2**: collapse the skill lists (`deploy-skills.ps1`/`sync-skills.ps1`/`AGENTS.md`), drop `sequential-tasks`, then run the `-GlobalOnly` propagation.
- **C3** (paused, needs sign-off): retire the monolith, delete `forge-workflow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)