### PR TITLE
fix: Claude session macros point at the constitution, not copilot-instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Claude session macros no longer point at Copilot's instruction file** — The
+  `ClaudeAwarenessMacro` and `ClaudeEnforcedMacro` injected after a Claude session
+  start (`internal/commands/storage.go`) told Claude to `Read @.github/copilot-instructions.md`.
+  That is CLI-specific verbiage in a Claude-facing macro, which contradicts the SDD
+  globalization goal of enforcing from one tool-agnostic source. Both macros now name
+  only `@.specify/memory/constitution.md` as the binding-rules source; the inline skill
+  cascade is unchanged. The Copilot/Google macros are untouched (they legitimately
+  reference their own tools' files). Guarded by a new
+  `TestClaudeMacrosOmitCopilotInstructions`.
+
 ## [7.13.0] - 2026-06-14
 
 ---

--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -103,17 +103,20 @@ type CardHistory struct {
 // identical text — no risk of the two drifting apart.
 var (
 	// ClaudeAwarenessMacro is injected after a fresh or resume Claude session.
-	// The skill order is spelled out explicitly here — pointing only to the
-	// instructions file is insufficient for resumed sessions where Claude may
-	// not re-read the file, and the file's own top-level pre-flight list does
-	// not yet enumerate framework-first directly.
-	ClaudeAwarenessMacro = "# SYSTEM INJECTION: FORGE AWARENESS\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read @.github/copilot-instructions.md and @.specify/memory/constitution.md before starting.\n# MANDATORY skill invocation order: workflow-enforcer → code-quality → framework-first → branching-strategy → code-tutor-workflow"
+	// It names ONLY the tool-agnostic constitution as the binding-rules source —
+	// never Copilot's .github/copilot-instructions.md, which is CLI-specific and
+	// does not belong in a Claude session. The skill order is spelled out inline
+	// because pointing only at a rules file is insufficient for resumed sessions
+	// where Claude may not re-read it, and the constitution does not enumerate
+	// framework-first directly.
+	ClaudeAwarenessMacro = "# SYSTEM INJECTION: FORGE AWARENESS\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read @.specify/memory/constitution.md before starting.\n# MANDATORY skill invocation order: workflow-enforcer → code-quality → framework-first → branching-strategy → code-tutor-workflow"
 
-	// ClaudeEnforcedMacro is injected after an enforced Claude session.
-	// Enforced mode applies the full quality gate on every task — framework-first
-	// is listed explicitly so the architecture-fidelity check cannot be skipped
-	// even when the agent does not re-read the instructions file.
-	ClaudeEnforcedMacro = "# SYSTEM INJECTION: FORGE AWARENESS — ENFORCED MODE\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read every rule in @.github/copilot-instructions.md and @.specify/memory/constitution.md before starting.\n# MANDATORY: Apply the workflow-enforcer rules to EVERY task without exception.\n# MANDATORY skill invocation order: workflow-enforcer → code-quality → framework-first → branching-strategy → code-tutor-workflow\n# NO SHORTCUTS — quality gates, naming rules, and TDD apply on every change."
+	// ClaudeEnforcedMacro is injected after an enforced Claude session. Like the
+	// awareness macro it names ONLY the tool-agnostic constitution, never Copilot's
+	// instruction file. Enforced mode applies the full quality gate on every task —
+	// framework-first is listed explicitly so the architecture-fidelity check cannot
+	// be skipped even when the agent does not re-read the constitution.
+	ClaudeEnforcedMacro = "# SYSTEM INJECTION: FORGE AWARENESS — ENFORCED MODE\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read every rule in @.specify/memory/constitution.md before starting.\n# MANDATORY: Apply the workflow-enforcer rules to EVERY task without exception.\n# MANDATORY skill invocation order: workflow-enforcer → code-quality → framework-first → branching-strategy → code-tutor-workflow\n# NO SHORTCUTS — quality gates, naming rules, and TDD apply on every change."
 
 	// CopilotWorkflowMacro is injected after any Copilot session to activate
 	// the Forge Workflow skill suite.

--- a/internal/commands/storage_test.go
+++ b/internal/commands/storage_test.go
@@ -116,7 +116,7 @@ func TestCommandsEqual_DetectsToggleChange(t *testing.T) {
 // architecture-fidelity gate fires before any code is written.
 //
 // Copilot and Google use step-numbered STEP 2 lists; Claude uses a # comment block
-// that points back to copilot-instructions.md. In the Claude case the macro MUST
+// that points at the tool-agnostic constitution. In the Claude case the macro MUST
 // spell out framework-first directly — relying on the agent to read through to the
 // workflow-enforcer skill body is too fragile a guarantee.
 //
@@ -152,6 +152,32 @@ func TestWorkflowMacrosOmitForgeWorkflow(t *testing.T) {
 	for macroName, macroText := range macrosUnderTest {
 		if contains(macroText, "forge-workflow") {
 			t.Errorf("%s still names the dissolved forge-workflow skill", macroName)
+		}
+	}
+}
+
+// TestClaudeMacrosOmitCopilotInstructions guards the cross-tool boundary created by
+// the SDD migration: a macro injected into a Claude session must NOT tell Claude to
+// read Copilot's instruction file (.github/copilot-instructions.md). The binding
+// rules now live in the tool-agnostic .specify/memory/constitution.md, which is the
+// only rules file a Claude macro should name. Naming Copilot's file inside a Claude
+// macro is CLI-specific verbiage that breaks the "enforce from Forge Terminal, one
+// source of truth" model — the exact regression this test exists to prevent.
+//
+// Only the Claude macros are asserted: the Copilot and Google macros legitimately
+// reference their own tools' files and are out of scope for this boundary.
+func TestClaudeMacrosOmitCopilotInstructions(t *testing.T) {
+	claudeMacros := map[string]string{
+		"ClaudeAwarenessMacro": ClaudeAwarenessMacro,
+		"ClaudeEnforcedMacro":  ClaudeEnforcedMacro,
+	}
+
+	for macroName, macroText := range claudeMacros {
+		if contains(macroText, "copilot-instructions") {
+			t.Errorf("%s tells Claude to read Copilot's instruction file; a Claude macro must point only at the tool-agnostic constitution", macroName)
+		}
+		if !contains(macroText, ".specify/memory/constitution.md") {
+			t.Errorf("%s must name the constitution as its binding-rules source", macroName)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The Claude session-start macros (`ClaudeAwarenessMacro`, `ClaudeEnforcedMacro` in `internal/commands/storage.go`) told Claude to `Read @.github/copilot-instructions.md`. That is **CLI-specific verbiage injected into a Claude session** — it contradicts the SDD globalization goal of enforcing from one tool-agnostic source.

## Change

- Both Claude macros now name **only** `@.specify/memory/constitution.md` as the binding-rules source.
- The inline mandatory skill cascade is unchanged, so nothing is lost — the constitution already carries the binding rules, and the skill order was always spelled out in the macro itself.
- **Copilot/Google macros are untouched** — they legitimately reference their own tools' files.
- Refreshed a now-stale comment in `TestWorkflowMacrosIncludeFrameworkFirst` that documented the old behavior.

## Test (TDD)

New `TestClaudeMacrosOmitCopilotInstructions` asserts the Claude macros (a) never contain `copilot-instructions` and (b) do name the constitution. Verified **red** before the fix, **green** after. Full `internal/commands` package passes; `go build ./cmd/forge/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)