### PR TITLE
fix: heal stale Claude card macros that referenced copilot-instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tab is never relabeled (the rename is now persisted across restarts). New
   `resolveProjectRoot` / `shouldRelabelForDirectory` helpers in `tabLabel.js` make the
   switch-only trigger drift-proof by construction.
+- **Claude "Enforced/Fresh/Resume" cards no longer inject Copilot's instruction file
+  into a Claude session** — Existing installs carried a stale Claude macro variant in
+  `~/.forge/commands.json` that pointed Claude at `@.github/copilot-instructions.md`
+  (and named the retired `forge-workflow` skill), violating FR-011 (a Claude session is
+  never routed through another tool's instruction file). The default cards in code were
+  already correct, but the migration only healed the *one* older generation that was
+  missing `framework-first`; the newer stale generation — which already contained
+  `framework-first` yet still referenced Copilot's file — slipped through. The migration
+  now heals the Claude macro variant of cards 6/7/8 against the **canonical** constant
+  (`ClaudeAwarenessMacro` / `ClaudeEnforcedMacro`, both pointing only at
+  `@.specify/memory/constitution.md`), so any drift self-heals on next launch, while a
+  user-authored macro (one without the Forge awareness header) is left untouched. New
+  `healClaudeMacroVariant` helper centralizes the rule.
 
 ## [7.15.0] - 2026-06-14
 

--- a/internal/commands/migration.go
+++ b/internal/commands/migration.go
@@ -100,6 +100,41 @@ func inferProviderFromCommand(command, description string) string {
 	return ""
 }
 
+// forgeAwarenessHeader marks a Claude session macro as Forge-managed (an awareness or
+// enforced macro), as opposed to one a user wrote by hand. Older generations of the
+// Forge macro carry this same header, which is what lets the heal below recognise — and
+// safely replace — a drifted Forge macro without clobbering a deliberate customisation.
+const forgeAwarenessHeader = "SYSTEM INJECTION: FORGE AWARENESS"
+
+// healClaudeMacroVariant rewrites a default card's Claude macro variant to the canonical
+// text whenever the stored value has drifted from it. Per FR-011 a Claude session must
+// be driven only by the tool-agnostic constitution and the current skill order — never
+// by an older generation that points at .github/copilot-instructions.md, names the
+// retired forge-workflow skill, or omits framework-first. Healing against the canonical
+// CONSTANT (rather than a per-symptom Contains check) means every future drift
+// self-heals; the previous code only caught the single "missing framework-first" case
+// and silently let the copilot-instructions reference survive. To avoid reverting an
+// intentional customisation, it heals only a missing/empty variant or one still carrying
+// the Forge awareness header. Returns true if it changed the card.
+func healClaudeMacroVariant(cmd *Command, canonicalClaudeMacro string) bool {
+	if cmd.MacroVariants == nil {
+		return false
+	}
+
+	current, exists := cmd.MacroVariants["claude"]
+	if current == canonicalClaudeMacro {
+		return false
+	}
+
+	isForgeManaged := !exists || current == "" || strings.Contains(current, forgeAwarenessHeader)
+	if !isForgeManaged {
+		return false
+	}
+
+	cmd.MacroVariants["claude"] = canonicalClaudeMacro
+	return true
+}
+
 // migrateToolVariants upgrades the legacy Copilot-specific cards (IDs 6, 7, 8)
 // to tool-agnostic cards with ToolVariants, DescriptionVariants, and
 // MacroVariants, and injects the Enforced card (ID 8) if it is missing.
@@ -153,17 +188,19 @@ func migrateToolVariants(commands []Command) ([]Command, bool) {
 				}
 				changed = true
 				log.Printf("[Commands] Migration: Added MacroVariants to ID 6")
-			} else if _, ok := commands[i].MacroVariants["google"]; !ok {
-				commands[i].MacroVariants["google"] = GoogleWorkflowMacro
-				changed = true
-				log.Printf("[Commands] Migration: Added Google MacroVariant to ID 6")
-			} else if !strings.Contains(commands[i].MacroVariants["claude"], "framework-first") {
-				// Installs from before the framework-first skill (2026-06-05) have a
-				// Claude macro that omits the architecture-fidelity gate from the skill
-				// cascade. Refresh to the current macro so the gate fires on session start.
-				commands[i].MacroVariants["claude"] = ClaudeAwarenessMacro
-				changed = true
-				log.Printf("[Commands] Migration: Updated Claude MacroVariant in ID 6 to include framework-first skill")
+			} else {
+				if _, ok := commands[i].MacroVariants["google"]; !ok {
+					commands[i].MacroVariants["google"] = GoogleWorkflowMacro
+					changed = true
+					log.Printf("[Commands] Migration: Added Google MacroVariant to ID 6")
+				}
+				// Heal a drifted Claude macro (e.g. one that still references Copilot's
+				// instruction file) back to the canonical awareness macro — independently
+				// of the Google check above, so a card can be missing neither yet still stale.
+				if healClaudeMacroVariant(&commands[i], ClaudeAwarenessMacro) {
+					changed = true
+					log.Printf("[Commands] Migration: Reset stale Claude MacroVariant in ID 6 to canonical awareness macro (FR-011)")
+				}
 			}
 
 		case 7:
@@ -207,16 +244,18 @@ func migrateToolVariants(commands []Command) ([]Command, bool) {
 				}
 				changed = true
 				log.Printf("[Commands] Migration: Added MacroVariants to ID 7")
-			} else if _, ok := commands[i].MacroVariants["google"]; !ok {
-				commands[i].MacroVariants["google"] = GoogleWorkflowMacro
-				changed = true
-				log.Printf("[Commands] Migration: Added Google MacroVariant to ID 7")
-			} else if !strings.Contains(commands[i].MacroVariants["claude"], "framework-first") {
-				// Same gap as ID 6 — resume sessions on pre-2026-06-05 installs need
-				// the architecture-fidelity gate added to the Claude session macro.
-				commands[i].MacroVariants["claude"] = ClaudeAwarenessMacro
-				changed = true
-				log.Printf("[Commands] Migration: Updated Claude MacroVariant in ID 7 to include framework-first skill")
+			} else {
+				if _, ok := commands[i].MacroVariants["google"]; !ok {
+					commands[i].MacroVariants["google"] = GoogleWorkflowMacro
+					changed = true
+					log.Printf("[Commands] Migration: Added Google MacroVariant to ID 7")
+				}
+				// Same heal as ID 6 — a resume card's Claude macro must point at the
+				// constitution, never Copilot's instruction file.
+				if healClaudeMacroVariant(&commands[i], ClaudeAwarenessMacro) {
+					changed = true
+					log.Printf("[Commands] Migration: Reset stale Claude MacroVariant in ID 7 to canonical awareness macro (FR-011)")
+				}
 			}
 
 		case 8:
@@ -264,17 +303,19 @@ func migrateToolVariants(commands []Command) ([]Command, bool) {
 				}
 				changed = true
 				log.Printf("[Commands] Migration: Added MacroVariants to ID 8")
-			} else if _, ok := commands[i].MacroVariants["google"]; !ok {
-				commands[i].MacroVariants["google"] = GoogleWorkflowMacro
-				changed = true
-				log.Printf("[Commands] Migration: Added Google MacroVariant to ID 8")
-			} else if !strings.Contains(commands[i].MacroVariants["claude"], "framework-first") {
-				// Enforced card on pre-2026-06-05 installs carries the old ClaudeEnforcedMacro
-				// which does not name framework-first. The enforced mode is the strictest gate
-				// and must include the architecture-fidelity skill explicitly.
-				commands[i].MacroVariants["claude"] = ClaudeEnforcedMacro
-				changed = true
-				log.Printf("[Commands] Migration: Updated Claude MacroVariant in ID 8 to include framework-first skill")
+			} else {
+				if _, ok := commands[i].MacroVariants["google"]; !ok {
+					commands[i].MacroVariants["google"] = GoogleWorkflowMacro
+					changed = true
+					log.Printf("[Commands] Migration: Added Google MacroVariant to ID 8")
+				}
+				// Enforced mode is the strictest gate, so its Claude macro must be exactly
+				// canonical. Heal any drifted generation — including the reported one that
+				// already named framework-first but still pointed at copilot-instructions.md.
+				if healClaudeMacroVariant(&commands[i], ClaudeEnforcedMacro) {
+					changed = true
+					log.Printf("[Commands] Migration: Reset stale Claude MacroVariant in ID 8 to canonical enforced macro (FR-011)")
+				}
 			}
 		}
 	}

--- a/internal/commands/migration_test.go
+++ b/internal/commands/migration_test.go
@@ -155,6 +155,108 @@ func TestMigrateToolVariants_AddsMacroVariantsToID7(t *testing.T) {
 	}
 }
 
+// The stale enforced macro a real install carried: it ALREADY names framework-first
+// (so the old `!Contains(..., "framework-first")` guard skipped it) yet still points a
+// Claude session at Copilot's instruction file and names the retired forge-workflow
+// skill — both FR-011 violations. This is the exact payload that mis-fired in the bug.
+const staleEnforcedClaudeMacro = "# SYSTEM INJECTION: FORGE AWARENESS — ENFORCED MODE\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read every rule in @.github/copilot-instructions.md before starting.\n# MANDATORY: Apply the workflow-enforcer rules to EVERY task without exception.\n# MANDATORY skill invocation order: workflow-enforcer → forge-workflow → code-quality → framework-first → branching-strategy → code-tutor-workflow\n# NO SHORTCUTS — quality gates, naming rules, and TDD apply on every change."
+
+const staleAwarenessClaudeMacro = "# SYSTEM INJECTION: FORGE AWARENESS\n# You are running inside Forge Terminal.\n# PROTECT PID: fterm.exe / forge.exe\n# MANDATORY: Read @.github/copilot-instructions.md before starting.\n# MANDATORY skill invocation order: workflow-enforcer → forge-workflow → code-quality → framework-first → branching-strategy → code-tutor-workflow"
+
+// fullyPopulatedVariants returns the variant maps a current card has, so a test can
+// isolate the Claude-macro heal from the unrelated empty/Google upgrade branches.
+func fullyPopulatedVariants(claudeMacro string) (map[string]string, map[string]string, map[string]string) {
+	toolVariants := map[string]string{"claude": "claude", "copilot": "copilot --allow-all-tools", "google": "agy --dangerously-skip-permissions"}
+	descriptionVariants := map[string]string{"claude": "🛡 Claude (Enforced)", "copilot": "🛡 Copilot (Enforced)", "google": "🛡 Google (Enforced)"}
+	macroVariants := map[string]string{"claude": claudeMacro, "copilot": CopilotWorkflowMacro, "google": GoogleWorkflowMacro}
+	return toolVariants, descriptionVariants, macroVariants
+}
+
+// TestMigrateToolVariants_HealsStaleEnforcedClaudeMacro is the regression test for the
+// reported bug: an Enforced card (ID 8) whose Claude macro still points at Copilot's
+// instruction file must be rewritten to the canonical constitution-based macro, even
+// though the stale text already contains "framework-first".
+func TestMigrateToolVariants_HealsStaleEnforcedClaudeMacro(t *testing.T) {
+	toolVariants, descriptionVariants, macroVariants := fullyPopulatedVariants(staleEnforcedClaudeMacro)
+	original := []Command{{
+		ID:                  8,
+		Description:         "🛡 Enforced",
+		Command:             "claude",
+		ToolVariants:        toolVariants,
+		DescriptionVariants: descriptionVariants,
+		MacroVariants:       macroVariants,
+	}}
+
+	migrated, changed := migrateToolVariants(original)
+	if !changed {
+		t.Fatal("expected migrateToolVariants to heal a stale Claude enforced macro")
+	}
+	claudeMacro := migrated[0].MacroVariants["claude"]
+	if claudeMacro != ClaudeEnforcedMacro {
+		t.Fatalf("Claude macro was not reset to canonical ClaudeEnforcedMacro; got %q", claudeMacro)
+	}
+	if strings.Contains(claudeMacro, "copilot-instructions") {
+		t.Fatalf("FR-011 violation: healed Claude macro still references Copilot's instruction file: %q", claudeMacro)
+	}
+	if !strings.Contains(claudeMacro, ".specify/memory/constitution.md") {
+		t.Fatalf("healed Claude macro must point at the constitution; got %q", claudeMacro)
+	}
+}
+
+// TestMigrateToolVariants_HealsStaleAwarenessClaudeMacro is the same regression for the
+// Fresh (ID 6) and Resume (ID 7) cards, which use the awareness (non-enforced) macro.
+func TestMigrateToolVariants_HealsStaleAwarenessClaudeMacro(t *testing.T) {
+	for _, id := range []int{6, 7} {
+		toolVariants, descriptionVariants, macroVariants := fullyPopulatedVariants(staleAwarenessClaudeMacro)
+		original := []Command{{
+			ID:                  id,
+			Description:         "🤖 Fresh",
+			Command:             "claude",
+			ToolVariants:        toolVariants,
+			DescriptionVariants: descriptionVariants,
+			MacroVariants:       macroVariants,
+		}}
+
+		migrated, changed := migrateToolVariants(original)
+		if !changed {
+			t.Fatalf("ID %d: expected migrateToolVariants to heal a stale awareness macro", id)
+		}
+		claudeMacro := migrated[0].MacroVariants["claude"]
+		if claudeMacro != ClaudeAwarenessMacro {
+			t.Fatalf("ID %d: Claude macro was not reset to canonical ClaudeAwarenessMacro; got %q", id, claudeMacro)
+		}
+		if strings.Contains(claudeMacro, "copilot-instructions") {
+			t.Fatalf("ID %d: FR-011 violation: healed macro still references Copilot's file: %q", id, claudeMacro)
+		}
+	}
+}
+
+// TestMigrateToolVariants_LeavesCanonicalAndCustomMacrosAlone guards against two false
+// positives: a card already carrying the canonical macro must not be rewritten (no
+// churn on every boot), and a genuinely user-authored macro (no Forge awareness
+// header) must never be clobbered.
+func TestMigrateToolVariants_LeavesCanonicalAndCustomMacrosAlone(t *testing.T) {
+	toolVariants, descriptionVariants, macroVariants := fullyPopulatedVariants(ClaudeEnforcedMacro)
+	canonical := []Command{{
+		ID: 8, Description: "🛡 Enforced", Command: "claude",
+		ToolVariants: toolVariants, DescriptionVariants: descriptionVariants, MacroVariants: macroVariants,
+	}}
+	if _, changed := migrateToolVariants(canonical); changed {
+		t.Fatal("a card already carrying the canonical Claude macro must not be rewritten")
+	}
+
+	customMacro := "My own Claude bootstrap. Read project.md. No Forge header here."
+	tv, dv, mv := fullyPopulatedVariants(customMacro)
+	custom := []Command{{
+		ID: 8, Description: "🛡 Enforced", Command: "claude",
+		ToolVariants: tv, DescriptionVariants: dv, MacroVariants: mv,
+	}}
+	migrated, _ := migrateToolVariants(custom)
+	if migrated[0].MacroVariants["claude"] != customMacro {
+		t.Fatalf("a user-authored Claude macro must be left untouched; got %q", migrated[0].MacroVariants["claude"])
+	}
+}
+
 // TestMigrateToolVariants_UpgradesExistingID8 verifies that when ID 8 is
 // present but lacks ToolVariants, the migration adds ToolVariants,
 // DescriptionVariants, and MacroVariants — fixing the silent upgrade gap


### PR DESCRIPTION
## What

Existing installs stored a Claude macro variant (launch cards 6/7/8) that pointed a **Claude** session at `@.github/copilot-instructions.md` and named the retired `forge-workflow` skill — violating **FR-011** (a Claude session is never routed through another tool's instruction file). The macro fired on session start, so every "🛡 Claude (Enforced)" launch injected the wrong instruction file.

## Root cause

The default cards in `storage.go` were already correct. But the migration only healed the *older* stale generation via `!Contains(claudeMacro, "framework-first")`. The newer stale generation already contained `framework-first` yet still referenced Copilot's file, so the guard was false and it was never healed.

## Fix

- New `healClaudeMacroVariant(cmd, canonical)` heals the Claude macro **against the canonical constant** (equality), not a per-symptom `Contains` — so any future drift self-heals. It only touches a missing/empty macro or one still carrying the `SYSTEM INJECTION: FORGE AWARENESS` header, leaving user-authored macros untouched.
- Restructured the ID 6/7/8 macro blocks so the Claude heal runs independently of the unrelated Google-variant branch.

Takes effect on next Forge Terminal start via `AutoMigrateOnLoad`.

## Tests

3 new tests (Red→Green) in `migration_test.go` reproducing the exact stale payload; `go test ./internal/commands/` ok, `go build ./cmd/forge/` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)