### PR TITLE
chore: Spec Kit hub-and-spoke install (no per-repo replication)

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -349,9 +349,20 @@ except Exception:
         done
     fi
 
-    # Priority 4: Core templates
+    # Priority 4: Core templates (repo-local)
     local core="$base/${template_name}.md"
     [ -f "$core" ] && echo "$core" && return 0
+
+    # Priority 5: Hub core templates — co-located with these scripts. This is the hub-and-spoke
+    # tier: a thin "spoke" repo (a .specify/ with only a constitution and no local templates)
+    # resolves core templates from the central hub these scripts live in. Skipped when the hub
+    # IS the repo (e.g. forge-terminal, the canonical source) — there Priority 4 already matched.
+    local hub_templates
+    hub_templates="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../templates" 2>/dev/null && pwd)" || hub_templates=""
+    if [ -n "$hub_templates" ] && [ "$hub_templates" != "$base" ]; then
+        local hub_core="$hub_templates/${template_name}.md"
+        [ -f "$hub_core" ] && echo "$hub_core" && return 0
+    fi
 
     # Template not found in any location.
     # Return 1 so callers can distinguish "not found" from "found".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passes (card renders, Approve injects the next command, Reject stops), confirming the
   decision card paints in the browser and the advance reaches the live terminal. Only T040
   (manual visual spot-check) is optional-remaining.
+- **Spec Kit hub-and-spoke install — no per-repo replication** — `scripts/deploy-speckit-hub.ps1`
+  publishes forge-terminal's canonical speckit machinery to a central hub (`~/.forge/speckit/`:
+  scripts, templates, extensions) and installs the global `speckit-*` skills with their script
+  paths rewritten to call the hub. A repo becomes a thin **spoke** carrying only
+  `.specify/memory/constitution.md` (via `scripts/speckit-spoke-init.ps1`) — every script and
+  template resolves from the hub, so a speckit change is made once and all spokes pick it up, and
+  onboarding a new repo is a single file. `common.sh` gains a Priority-5 template tier that falls
+  back to the templates co-located with the scripts (the hub), so a spoke needs no local
+  templates. Verified end-to-end: a constitution-only repo runs `/speckit-specify` → `setup-plan`
+  with templates served from the hub.
 
 ### Fixed
 - **A tab now relabels when the shell switches to a different project root** — After

--- a/scripts/deploy-speckit-hub.ps1
+++ b/scripts/deploy-speckit-hub.ps1
@@ -1,0 +1,68 @@
+# deploy-speckit-hub.ps1 — Builds the central Spec Kit HUB and installs the global, hub-calling
+# speckit skills. This is the SINGLE maintenance point for the hub-and-spoke model: forge-terminal
+# is the canonical source; running this script publishes its machinery so every spoke repo (any
+# repo with a .specify/ + constitution) picks up the change without per-repo replication.
+#
+# What it produces:
+#   ~/.forge/speckit/{scripts,templates,extensions}   — shared machinery (one copy, machine-wide)
+#   ~/.claude/skills/speckit-*                          — global skills, with their script paths
+#                                                          rewritten from .specify/scripts/bash/ to
+#                                                          the hub, so they call the hub from anywhere
+#
+# A spoke repo therefore needs only: .specify/memory/constitution.md (its own rules). The scripts
+# resolve the repo from the current directory (find_specify_root) and read templates from the hub
+# (common.sh Priority-5 fallback).
+#
+# Usage:  .\scripts\deploy-speckit-hub.ps1            # build/refresh the hub + global skills
+#         .\scripts\deploy-speckit-hub.ps1 -DryRun    # preview without writing
+
+param([switch]$DryRun)
+$ErrorActionPreference = "Stop"
+
+$forgeRoot   = Split-Path $PSScriptRoot -Parent
+$specifySrc  = Join-Path $forgeRoot ".specify"
+$skillsSrc   = Join-Path $forgeRoot ".claude\skills"
+$hub         = Join-Path $env:USERPROFILE ".forge\speckit"
+$globalSkills = Join-Path $env:USERPROFILE ".claude\skills"
+
+# The literal path written INTO the skills. Single-quoted so $HOME stays literal — the agent's
+# bash expands it at run time, which works cross-platform (unlike a hard-coded C:\Users\... path).
+$hubScriptPath = '$HOME/.forge/speckit/scripts/bash/'
+
+Write-Host "Spec Kit hub deploy ($(if ($DryRun) { 'DRY RUN' } else { 'LIVE' }))" -ForegroundColor Cyan
+Write-Host "  source: $forgeRoot"
+Write-Host "  hub:    $hub"
+
+# 1. Machinery -> hub (scripts, templates, extensions). Replace wholesale so removals propagate.
+foreach ($part in @("scripts", "templates", "extensions")) {
+    $src = Join-Path $specifySrc $part
+    $dst = Join-Path $hub $part
+    if (-not (Test-Path $src)) { continue }
+    if ($DryRun) { Write-Host "  would sync .specify/$part -> $dst"; continue }
+    if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $hub | Out-Null
+    Copy-Item $src $dst -Recurse -Force
+    Write-Host "  synced .specify/$part" -ForegroundColor Green
+}
+
+# 2. Global hub-calling skills: copy each speckit-* skill and rewrite its script invocations to
+#    the hub. Deriving them (rather than hand-editing) keeps forge-terminal the single source.
+$skillCount = 0
+Get-ChildItem $skillsSrc -Directory -Filter "speckit-*" | ForEach-Object {
+    $dst = Join-Path $globalSkills $_.Name
+    if ($DryRun) { Write-Host "  would install skill $($_.Name) (paths -> hub)"; return }
+    if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $globalSkills | Out-Null
+    Copy-Item $_.FullName $dst -Recurse -Force
+    Get-ChildItem $dst -Recurse -Filter "*.md" | ForEach-Object {
+        $content = Get-Content $_.FullName -Raw
+        $rewritten = $content -replace '\.specify/scripts/bash/', $hubScriptPath
+        if ($rewritten -ne $content) { [IO.File]::WriteAllText($_.FullName, $rewritten) }
+    }
+    $script:skillCount++
+}
+
+if (-not $DryRun) {
+    Write-Host "Done. Hub at $hub; $skillCount global speckit skills call the hub." -ForegroundColor Green
+    Write-Host "Onboard a repo as a spoke with: .\scripts\speckit-spoke-init.ps1 -Target <repo>" -ForegroundColor Gray
+}

--- a/scripts/speckit-spoke-init.ps1
+++ b/scripts/speckit-spoke-init.ps1
@@ -1,0 +1,36 @@
+# speckit-spoke-init.ps1 — Onboard a repository as a Spec Kit SPOKE. Creates only the per-repo
+# part (.specify/memory/constitution.md); every script and template comes from the central hub
+# (~/.forge/speckit), so there is nothing to replicate or maintain per repo. Run the hub deploy
+# (deploy-speckit-hub.ps1) once first.
+#
+# Usage:  .\scripts\speckit-spoke-init.ps1 -Target C:\Path\To\Repo
+#         .\scripts\speckit-spoke-init.ps1 -Target C:\Path\To\Repo -Force   # overwrite constitution
+
+param(
+    [Parameter(Mandatory)][string]$Target,
+    [switch]$Force
+)
+$ErrorActionPreference = "Stop"
+
+$hub = Join-Path $env:USERPROFILE ".forge\speckit"
+if (-not (Test-Path $hub)) { throw "Hub not found at $hub — run scripts\deploy-speckit-hub.ps1 first." }
+if (-not (Test-Path $Target)) { throw "Target repo not found: $Target" }
+
+$memoryDir    = Join-Path $Target ".specify\memory"
+$constitution = Join-Path $memoryDir "constitution.md"
+New-Item -ItemType Directory -Force -Path $memoryDir | Out-Null
+
+if ((Test-Path $constitution) -and -not $Force) {
+    Write-Host "Constitution already present: $constitution (use -Force to overwrite)." -ForegroundColor Yellow
+} else {
+    $template = Join-Path $hub "templates\constitution-template.md"
+    if (Test-Path $template) {
+        Copy-Item $template $constitution -Force
+    } else {
+        Set-Content -Path $constitution -Value "# $(Split-Path $Target -Leaf) — Project Constitution`n`n> Placeholder. Run /speckit-constitution in this repo to author its binding rules."
+    }
+    Write-Host "Wrote $constitution" -ForegroundColor Green
+}
+
+Write-Host "Spoke ready: /speckit-* now works in $Target (all machinery resolves from the hub)." -ForegroundColor Green
+Write-Host "Next, in that repo: run /speckit-constitution to author its rules, then /speckit-specify." -ForegroundColor Gray


### PR DESCRIPTION
## Problem

Every repo that wanted `/speckit-*` had to carry a full copy of `.specify/` (scripts, templates,
extensions). That's duplicated infrastructure: a speckit change meant editing every repo, and a
new repo meant copying the whole tree.

## Solution — hub-and-spoke

```
deploy-speckit-hub.ps1  →  ~/.forge/speckit/{scripts,templates,extensions}   (the hub, one copy)
                        →  ~/.claude/skills/speckit-*  (global skills, script paths → hub)

speckit-spoke-init.ps1  →  <repo>/.specify/memory/constitution.md            (the only per-repo file)
```

- **Spokes carry only a constitution.** Scripts + templates resolve from the hub.
- **One maintenance point:** change speckit in forge-terminal → run `deploy-speckit-hub.ps1` → every spoke picks it up. New repo = one file (`speckit-spoke-init.ps1`).
- The global skills are **derived** (script paths rewritten from `.specify/scripts/bash/` → the hub) — never hand-edited, so forge-terminal stays the single source.

## The one-line enabler

`common.sh resolve_template` gains a **Priority-5** tier: templates co-located with the running
scripts (i.e. the hub), reached only when the repo has no local templates. In forge-terminal (the
source) Priority 4 still matches, so it's a no-op there; in a thin spoke it serves the hub's
templates. forge-terminal keeps its project-level speckit skills (local-calling), so it's
unaffected; every other repo uses the global hub-calling skills.

## Verification

A constitution-only temp repo ran `create-new-feature.sh` (the `/speckit-specify` backend) and
`setup-plan.sh` end-to-end, with `spec.md`/`plan.md` templates served from the hub — proving a
spoke needs zero local machinery.

## Files

- `.specify/scripts/bash/common.sh` — Priority-5 hub template fallback
- `scripts/deploy-speckit-hub.ps1` — build/refresh the hub + global skills (single maintenance point)
- `scripts/speckit-spoke-init.ps1` — onboard a repo as a thin spoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)