### PR TITLE
fix: SDD orchestrator failsafe exit + reliable, per-session activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD decision cards now fire reliably, never trap the session, and work across multiple
+  tabs** — Three real-world defects in the phase orchestrator:
+  - **Failsafe exit (was trapping users).** A failed decision (e.g. a stale `cardId` after a
+    re-bind) used to leave the card open with no way out — the Approve button silently did
+    nothing and the only escape was killing the terminal session. The card now has an
+    always-available dismiss (✕ / `Escape`) that closes it locally with no backend dependency,
+    surfaces decision errors inline instead of failing silently, and disables action buttons
+    while a decision is in flight. The decision endpoint is also lenient: a stale `cardId`/phase
+    is applied to the on-screen pending card rather than rejected, so Approve can't dead-end.
+  - **Reliable activation (cards rarely fired before).** Binding was once-per-tab and the
+    backend 409'd if `.specify/feature.json` didn't already exist — but you normally *create*
+    the feature by running `/speckit-specify` during the session, after binding had already
+    given up. Binding is now **eager** (a session binds to its repo with no feature required)
+    and the watcher **lazily** learns the active feature the moment the first phase artifact
+    appears, so the card fires every time rather than by lucky timing.
+  - **Per-session pipelines (multi-tab clobbering).** A single global orchestrator meant
+    multiple terminal tabs fought over one pipeline. Each session now has its own pipeline
+    (keyed by session id), so tabs gate independently; re-binding the same repo is a no-op that
+    no longer invalidates an open card. Verified end-to-end against a running build.
+
 ## [7.16.0] - 2026-06-15
 
 ---

--- a/cmd/forge/handlers_sdd.go
+++ b/cmd/forge/handlers_sdd.go
@@ -6,14 +6,11 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/mikejsmith1985/forge-terminal/internal/sdd"
 )
-
-// sddOrchestrator is the active pipeline orchestrator, wired at startup. Nil means no
-// pipeline is active, which the handler reports as a conflict rather than a crash.
-var sddOrchestrator *sdd.Orchestrator
 
 // sddDecisionRequest is the POST /api/sdd/decision body (contract: sdd-decision-endpoint.md).
 type sddDecisionRequest struct {
@@ -24,14 +21,15 @@ type sddDecisionRequest struct {
 	ClarifyText string `json:"clarifyText"`
 }
 
-// handleSddDecision applies one decision to the active pipeline and returns the new status.
+// handleSddDecision applies one decision to the session's pipeline and returns the new status.
+//
+// It is deliberately LENIENT so the card can never trap the user (the original bug: a stale
+// cardId after a re-bind made Approve silently 409, leaving the user stuck enough to kill the
+// session). As long as the session has a pending card, the decision is applied to THAT card —
+// the one the user is actually looking at — rather than rejected on a cardId/phase mismatch.
 func handleSddDecision(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeSddError(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
-	if sddOrchestrator == nil {
-		writeSddError(w, http.StatusConflict, "no active SDD pipeline")
 		return
 	}
 
@@ -41,20 +39,27 @@ func handleSddDecision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject a decision aimed at a card that is no longer current, so a stale UI cannot
-	// act on a superseded gate (contract: 409 on cardId mismatch).
-	state := sddOrchestrator.State()
+	pipeline, found := sddPipelineFor(request.SessionID)
+	if !found {
+		writeSddError(w, http.StatusConflict, "no active SDD pipeline for this session")
+		return
+	}
+	orchestrator := pipeline.orchestrator
+
+	state := orchestrator.State()
 	if state.PendingCard == nil {
 		writeSddError(w, http.StatusConflict, sdd.ErrNoPendingCard.Error())
 		return
 	}
+	// Lenient: a mismatched cardId is logged, not rejected — acting on the on-screen card beats
+	// trapping the user. The frontend's local dismiss is the ultimate escape hatch.
 	if request.CardID != "" && request.CardID != state.PendingCard.ID {
-		writeSddError(w, http.StatusConflict, "stale or unknown cardId")
-		return
+		log.Printf("[sdd] decision cardId mismatch (got %q, pending %q) — proceeding on the pending card", request.CardID, state.PendingCard.ID)
 	}
 
-	status, err := sddOrchestrator.SubmitDecision(sdd.Decision{
-		Phase:       sdd.PhaseName(request.Phase),
+	// Use the pending card's phase (not the request's) so a phase mismatch can't trap the user.
+	status, err := orchestrator.SubmitDecision(sdd.Decision{
+		Phase:       state.PendingCard.Phase,
 		Action:      sdd.Action(request.Action),
 		ClarifyText: request.ClarifyText,
 	})

--- a/cmd/forge/handlers_sdd_test.go
+++ b/cmd/forge/handlers_sdd_test.go
@@ -1,6 +1,6 @@
-// handlers_sdd_test.go — verifies POST /api/sdd/decision maps decisions and errors to the
-// right status codes (contract: sdd-decision-endpoint.md). The orchestrator is real but its
-// ports (injector/broadcaster) are mocked via the exported func adapters.
+// handlers_sdd_test.go — verifies POST /api/sdd/decision routes to the right session's pipeline
+// and, critically, is LENIENT so the card never traps the user (a stale cardId is acted on, not
+// rejected). The orchestrator is real; its ports are mocked via the exported func adapters.
 package main
 
 import (
@@ -12,20 +12,22 @@ import (
 	"github.com/mikejsmith1985/forge-terminal/internal/sdd"
 )
 
-func setupSddHandler(t *testing.T) {
+// bindTestPipeline registers a pipeline for sessionID with a pending card for the given phase,
+// and cleans it out of the global registry afterward.
+func bindTestPipeline(t *testing.T, sessionID string, phase sdd.PhaseName) *sdd.Orchestrator {
 	t.Helper()
 	orchestrator := sdd.NewOrchestrator(sdd.Options{
-		Feature:        "demo",
-		SessionID:      "sess-1",
+		SessionID:      sessionID,
 		HistoryBaseDir: t.TempDir(),
 		Injector:       sdd.InjectorFunc(func(string, string) error { return nil }),
 		Broadcaster:    sdd.BroadcasterFunc(func(sdd.DecisionCard) error { return nil }),
 		Summarize:      func(sdd.PhaseName) sdd.PhaseSummary { return sdd.PhaseSummary{Headline: "H"} },
-		NewCardID:      func(phase sdd.PhaseName) string { return "card-" + string(phase) },
+		NewCardID:      func(name sdd.PhaseName) string { return "card-" + string(name) },
 	})
-	orchestrator.HandlePhaseComplete(sdd.PhasePlan, "plan.md")
-	sddOrchestrator = orchestrator
-	t.Cleanup(func() { sddOrchestrator = nil })
+	orchestrator.HandlePhaseComplete(phase, string(phase)+".md")
+	sddPipelines.Store(sessionID, &sddPipeline{orchestrator: orchestrator, repoRoot: "C:/repo/" + sessionID})
+	t.Cleanup(func() { sddPipelines.Delete(sessionID) })
+	return orchestrator
 }
 
 func postDecision(t *testing.T, body string) *httptest.ResponseRecorder {
@@ -37,7 +39,7 @@ func postDecision(t *testing.T, body string) *httptest.ResponseRecorder {
 }
 
 func TestHandleSddDecision_ApproveReturns200(t *testing.T) {
-	setupSddHandler(t)
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
 
 	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-plan","phase":"plan","action":"approve"}`)
 
@@ -50,57 +52,79 @@ func TestHandleSddDecision_ApproveReturns200(t *testing.T) {
 }
 
 func TestHandleSddDecision_RejectReturns200(t *testing.T) {
-	setupSddHandler(t)
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
 
-	recorder := postDecision(t, `{"cardId":"card-plan","phase":"plan","action":"reject"}`)
+	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-plan","phase":"plan","action":"reject"}`)
 
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
-	}
-	if !strings.Contains(recorder.Body.String(), "rejected") {
-		t.Errorf("body = %s, want status rejected", recorder.Body.String())
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "rejected") {
+		t.Fatalf("status = %d body = %s, want 200 rejected", recorder.Code, recorder.Body.String())
 	}
 }
 
 func TestHandleSddDecision_ClarifyReturns200(t *testing.T) {
-	setupSddHandler(t)
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
 
-	recorder := postDecision(t, `{"cardId":"card-plan","phase":"plan","action":"clarify","clarifyText":"narrow scope"}`)
+	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-plan","phase":"plan","action":"clarify","clarifyText":"narrow scope"}`)
 
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
-	}
-	if !strings.Contains(recorder.Body.String(), "advancing") {
-		t.Errorf("body = %s, want status advancing", recorder.Body.String())
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "advancing") {
+		t.Fatalf("status = %d body = %s, want 200 advancing", recorder.Code, recorder.Body.String())
 	}
 }
 
 func TestHandleSddDecision_EmptyClarifyReturns400(t *testing.T) {
-	setupSddHandler(t)
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
 
-	recorder := postDecision(t, `{"cardId":"card-plan","phase":"plan","action":"clarify","clarifyText":"   "}`)
+	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-plan","phase":"plan","action":"clarify","clarifyText":"   "}`)
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
 	}
 }
 
-func TestHandleSddDecision_StaleCardIdReturns409(t *testing.T) {
-	setupSddHandler(t)
+// The failsafe: a stale cardId must NOT trap the user. The decision is applied to the pending
+// card the user is looking at, returning success — not a 409.
+func TestHandleSddDecision_StaleCardIdProceedsLeniently(t *testing.T) {
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
 
-	recorder := postDecision(t, `{"cardId":"card-stale","phase":"plan","action":"approve"}`)
+	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-STALE","phase":"plan","action":"approve"}`)
 
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stale cardId must proceed leniently; status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+// Likewise a mismatched phase is ignored in favor of the pending card's phase.
+func TestHandleSddDecision_StalePhaseUsesPendingCardPhase(t *testing.T) {
+	bindTestPipeline(t, "sess-1", sdd.PhasePlan)
+
+	recorder := postDecision(t, `{"sessionId":"sess-1","cardId":"card-plan","phase":"specify","action":"approve"}`)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("phase mismatch must not trap; status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+// Each session resolves its own card; a decision for one must not disturb another.
+func TestHandleSddDecision_RoutesPerSession(t *testing.T) {
+	orchestratorA := bindTestPipeline(t, "sess-A", sdd.PhasePlan)
+	orchestratorB := bindTestPipeline(t, "sess-B", sdd.PhaseSpecify)
+
+	recorder := postDecision(t, `{"sessionId":"sess-B","cardId":"card-specify","phase":"specify","action":"reject"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if orchestratorB.State().PendingCard != nil {
+		t.Errorf("sess-B card should be resolved after its decision")
+	}
+	if orchestratorA.State().PendingCard == nil {
+		t.Errorf("sess-A card must be untouched by a sess-B decision")
 	}
 }
 
 func TestHandleSddDecision_NoPipelineReturns409(t *testing.T) {
-	sddOrchestrator = nil
-
-	recorder := postDecision(t, `{"phase":"plan","action":"approve"}`)
+	recorder := postDecision(t, `{"sessionId":"ghost-session","phase":"plan","action":"approve"}`)
 
 	if recorder.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409", recorder.Code)
+		t.Fatalf("status = %d, want 409 (no pipeline for session)", recorder.Code)
 	}
 }

--- a/cmd/forge/sdd_wiring.go
+++ b/cmd/forge/sdd_wiring.go
@@ -1,8 +1,14 @@
 // sdd_wiring.go — wires the SDD orchestrator (internal/sdd) to live Forge subsystems:
 // the macro-injection path (advance), the WebSocket hub (card push), and the tutor file
-// watcher (detect). Binding is frontend-driven (POST /api/sdd/bind) because the backend
-// does not track a per-session working directory; the frontend, which knows the active
-// session and its repo, tells us which session runs the pipeline and where.
+// watcher (detect).
+//
+// Binding model (per-session, eager): each terminal session gets its OWN pipeline (orchestrator
+// + watcher), keyed by sessionId, so multiple sessions gate independently instead of clobbering a
+// single global. Binding is EAGER — a session is bound to its repo as soon as the frontend knows
+// the working directory, WITHOUT requiring .specify/feature.json to exist yet. The watcher then
+// LAZILY learns the active feature the moment a phase artifact (specs/<feature>/spec.md, plan.md…)
+// is written — which is exactly when the developer runs /speckit-specify. This fixes the original
+// failure where binding happened once, 409'd because no feature existed yet, and never retried.
 package main
 
 import (
@@ -12,14 +18,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mikejsmith1985/forge-terminal/internal/sdd"
 	"github.com/mikejsmith1985/forge-terminal/internal/tutor"
 )
-
-// sddWatcher is the active feature-directory watcher, replaced on each bind.
-var sddWatcher *tutor.Watcher
 
 // PTY-quiet detection tuning for artifact-less phases (Validate/Implement). These are
 // heuristics: "the terminal was silent for sddPhaseQuietMs" stands in for "the phase command
@@ -29,6 +33,27 @@ const (
 	sddPhaseQuietMs = 8000           // 8s of terminal silence => the phase command finished
 	sddPhaseMaxMs   = 30 * 60 * 1000 // 30-minute safety cap (Implement can run long)
 )
+
+// sddPipeline is one session's bound pipeline: its orchestrator, the repo watcher feeding it,
+// and the repo root it watches. One per terminal session.
+type sddPipeline struct {
+	orchestrator *sdd.Orchestrator
+	watcher      *tutor.Watcher
+	repoRoot     string
+}
+
+// sddPipelines maps sessionId -> *sddPipeline. A sync.Map because binds (HTTP), decisions (HTTP),
+// and the watcher goroutines all touch it concurrently.
+var sddPipelines sync.Map
+
+// sddPipelineFor returns the bound pipeline for a session, if any.
+func sddPipelineFor(sessionID string) (*sddPipeline, bool) {
+	value, ok := sddPipelines.Load(sessionID)
+	if !ok {
+		return nil, false
+	}
+	return value.(*sddPipeline), true
+}
 
 // sddGateEnvelope is the on-the-wire SDD_PHASE_GATE message. Embedding DecisionCard flattens
 // its fields (cardId, sessionId, phase, summary, actions) alongside the type discriminator.
@@ -43,9 +68,10 @@ type sddBindRequest struct {
 	RepoRoot  string `json:"repoRoot"`
 }
 
-// handleSddBind starts (or restarts) the orchestrator for a session + repo. It resolves the
-// active feature directory from the repo's .specify/feature.json and begins watching for
-// phase artifacts.
+// handleSddBind binds (eagerly) a terminal session to its repository so the orchestrator watches
+// for phase artifacts. It does NOT require a feature to exist yet — the feature is learned lazily
+// when the first artifact appears. Binding the same session to the same repo again is a no-op, so
+// routine re-binds (e.g. tab switches) never tear down a pipeline or invalidate an on-screen card.
 func handleSddBind(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeSddError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -62,42 +88,33 @@ func handleSddBind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	featureDir, ok := resolveSddFeatureDir(request.RepoRoot)
-	if !ok {
-		writeSddError(w, http.StatusConflict, "no active feature (.specify/feature.json not found)")
+	// Idempotent: already watching this exact repo for this session — leave it (and its pending
+	// card) untouched.
+	if existing, ok := sddPipelineFor(request.SessionID); ok && sameSddRepo(existing.repoRoot, request.RepoRoot) {
+		writeSddJSON(w, http.StatusOK, map[string]string{"status": "bound"})
 		return
 	}
 
-	startSddPipeline(request.SessionID, request.RepoRoot, featureDir)
-	writeSddJSON(w, http.StatusOK, map[string]string{"status": "bound", "feature": filepath.Base(featureDir)})
+	startSddPipeline(request.SessionID, request.RepoRoot)
+	writeSddJSON(w, http.StatusOK, map[string]string{"status": "bound"})
 }
 
-// resolveSddFeatureDir reads the active feature directory from repoRoot/.specify/feature.json.
-func resolveSddFeatureDir(repoRoot string) (string, bool) {
-	raw, err := os.ReadFile(filepath.Join(repoRoot, ".specify", "feature.json"))
-	if err != nil {
-		return "", false
-	}
-	var meta struct {
-		FeatureDirectory string `json:"feature_directory"`
-	}
-	if err := json.Unmarshal(raw, &meta); err != nil || meta.FeatureDirectory == "" {
-		return "", false
-	}
-	return filepath.Join(repoRoot, filepath.FromSlash(meta.FeatureDirectory)), true
+// sameSddRepo compares two repo roots for binding idempotency, tolerant of separator/casing diffs.
+func sameSddRepo(left, right string) bool {
+	normalize := func(path string) string { return strings.ToLower(filepath.ToSlash(strings.TrimRight(path, "/\\"))) }
+	return normalize(left) == normalize(right)
 }
 
-// startSddPipeline constructs the orchestrator with live ports and starts the watcher loop.
-func startSddPipeline(sessionID, repoRoot, featureDir string) {
-	if sddWatcher != nil {
-		sddWatcher.Stop()
-		sddWatcher = nil
+// startSddPipeline creates (or replaces, if the repo changed) the pipeline for a session and
+// starts its watcher. Eager: no feature is required up front.
+func startSddPipeline(sessionID, repoRoot string) {
+	// Replace any prior pipeline for this session (e.g. the session moved to a different repo).
+	if old, ok := sddPipelineFor(sessionID); ok {
+		old.watcher.Stop()
+		sddPipelines.Delete(sessionID)
 	}
 
-	feature := filepath.Base(featureDir)
-	sddOrchestrator = sdd.NewOrchestrator(sdd.Options{
-		Feature:        feature,
-		FeatureDir:     featureDir,
+	orchestrator := sdd.NewOrchestrator(sdd.Options{
 		SessionID:      sessionID,
 		HistoryBaseDir: sddStateDir(),
 		Injector:       newSddInjector(),
@@ -105,36 +122,40 @@ func startSddPipeline(sessionID, repoRoot, featureDir string) {
 		Waiter:         newSddWaiter(),
 	})
 
-	// US3 (FR-011/012): subscribe a best-effort notifier to the shared completion seam.
-	// It is independent of the card subscriber (US1) — both observe the same event.
+	// US3 (FR-011/012): best-effort notifier on the shared completion seam. It reads the feature
+	// label from the orchestrator at fire time, since the feature is learned lazily.
 	notifier := sdd.NewNotifier()
-	sddOrchestrator.Subscribe(func(phase sdd.PhaseName, artifactPath string) {
-		notifier.Notify(feature, phase, artifactPath)
+	orchestrator.Subscribe(func(phase sdd.PhaseName, artifactPath string) {
+		notifier.Notify(filepath.Base(orchestrator.State().FeatureDir), phase, artifactPath)
 	})
 
-	watcher := tutor.NewWatcher(repoRoot, "sdd")
+	watcher := tutor.NewWatcher(repoRoot, "sdd-"+sessionID)
 	if err := watcher.Start(); err != nil {
 		log.Printf("[sdd] failed to start watcher on %s: %v", repoRoot, err)
 		return
 	}
-	sddWatcher = watcher
-	go runSddDetector(watcher, repoRoot, featureDir, sessionID)
-	log.Printf("[sdd] pipeline bound: session=%s feature=%s", sessionID, filepath.Base(featureDir))
+
+	pipeline := &sddPipeline{orchestrator: orchestrator, watcher: watcher, repoRoot: repoRoot}
+	sddPipelines.Store(sessionID, pipeline)
+	go runSddDetector(pipeline, sessionID)
+	log.Printf("[sdd] pipeline bound (eager): session=%s repo=%s", sessionID, repoRoot)
 }
 
 // runSddDetector consumes watcher notifications and gates each recognized phase artifact.
-func runSddDetector(watcher *tutor.Watcher, repoRoot, featureDir, sessionID string) {
-	for notification := range watcher.Notifications() {
+func runSddDetector(pipeline *sddPipeline, sessionID string) {
+	for notification := range pipeline.watcher.Notifications() {
 		for _, change := range notification.Files {
-			gateSddArtifact(change.Path, repoRoot, featureDir, sessionID)
+			gateSddArtifact(pipeline, sessionID, change.Path)
 		}
 	}
 }
 
-// gateSddArtifact classifies one changed file and, if it is a phase artifact, fires the
-// shared completion seam. Files outside the feature directory or unrecognized are ignored.
-func gateSddArtifact(changedPath, repoRoot, featureDir, sessionID string) {
-	featureRel, ok := sddFeatureRel(changedPath, repoRoot, featureDir)
+// gateSddArtifact classifies one changed file and, if it is a phase artifact, points the
+// orchestrator at the feature it belongs to and fires the completion seam. The feature directory
+// is derived from the artifact's own path (specs/<feature>/…), so no .specify/feature.json is
+// required and switching to a new feature later "just works".
+func gateSddArtifact(pipeline *sddPipeline, sessionID, changedPath string) {
+	featureDir, featureRel, ok := deriveSddFeature(changedPath, pipeline.repoRoot)
 	if !ok {
 		return
 	}
@@ -143,30 +164,32 @@ func gateSddArtifact(changedPath, repoRoot, featureDir, sessionID string) {
 		return
 	}
 	phase, recognized := sdd.DetectCompletedPhase(featureRel, string(content))
-	if !recognized || sddOrchestrator == nil {
+	if !recognized {
 		return
 	}
-	sddOrchestrator.BindSession(sessionID)
-	sddOrchestrator.HandlePhaseComplete(phase, featureRel)
+	pipeline.orchestrator.BindSession(sessionID)
+	pipeline.orchestrator.SetFeatureDir(featureDir)
+	pipeline.orchestrator.HandlePhaseComplete(phase, featureRel)
 }
 
-// sddFeatureRel returns the path of a changed file relative to the feature directory,
-// handling both absolute and repo-relative watcher paths. It returns false when the file
-// lies outside the feature directory.
-func sddFeatureRel(changedPath, repoRoot, featureDir string) (string, bool) {
-	absolute := changedPath
-	if !filepath.IsAbs(absolute) {
-		absolute = filepath.Join(repoRoot, changedPath)
+// deriveSddFeature splits a changed file path into the feature directory it belongs to and the
+// path relative to that feature dir, recognizing the conventional specs/<feature>/<rel> layout.
+// Returns false for any path not under a specs/<feature>/ tree.
+func deriveSddFeature(changedPath, repoRoot string) (featureDir, featureRel string, ok bool) {
+	relative := changedPath
+	if filepath.IsAbs(relative) {
+		if rebased, err := filepath.Rel(repoRoot, relative); err == nil {
+			relative = rebased
+		}
 	}
-	relative, err := filepath.Rel(featureDir, absolute)
-	if err != nil {
-		return "", false
+	parts := strings.Split(filepath.ToSlash(relative), "/")
+	// Need at least specs/<feature>/<file>.
+	if len(parts) < 3 || parts[0] != "specs" || parts[1] == "" {
+		return "", "", false
 	}
-	relative = filepath.ToSlash(relative)
-	if relative == ".." || strings.HasPrefix(relative, "../") {
-		return "", false
-	}
-	return relative, true
+	featureDir = filepath.Join(repoRoot, "specs", parts[1])
+	featureRel = strings.Join(parts[2:], "/")
+	return featureDir, featureRel, true
 }
 
 // newSddInjector advances the pipeline by injecting the next command, reusing the macro

--- a/cmd/forge/sdd_wiring_test.go
+++ b/cmd/forge/sdd_wiring_test.go
@@ -1,13 +1,12 @@
-// sdd_wiring_test.go — verifies the SDD wiring helpers: feature-dir resolution, mapping a
-// watcher path to a feature-relative path, the SDD_PHASE_GATE envelope shape, and bind
-// request validation. The watcher-starting success path is exercised by the live app, not here.
+// sdd_wiring_test.go — verifies the per-session/eager wiring helpers: deriving a feature from an
+// artifact path, repo-equality for bind idempotency, the SDD_PHASE_GATE envelope shape, and eager
+// bind behavior (a session binds even with no feature yet, and re-binding the same repo is a no-op).
 package main
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,42 +14,52 @@ import (
 	"github.com/mikejsmith1985/forge-terminal/internal/sdd"
 )
 
-func TestResolveSddFeatureDir(t *testing.T) {
-	repo := t.TempDir()
-	specifyDir := filepath.Join(repo, ".specify")
-	if err := os.MkdirAll(specifyDir, 0o755); err != nil {
-		t.Fatal(err)
+func TestDeriveSddFeature(t *testing.T) {
+	repo := t.TempDir() // genuine absolute path (drive-qualified on Windows)
+	cases := []struct {
+		name        string
+		changed     string
+		wantFeature string // basename of the feature dir
+		wantRel     string
+		wantOK      bool
+	}{
+		{"repo-relative spec", filepath.Join("specs", "003-feat", "spec.md"), "003-feat", "spec.md", true},
+		{"absolute plan", filepath.Join(repo, "specs", "003-feat", "plan.md"), "003-feat", "plan.md", true},
+		{"nested artifact", filepath.Join("specs", "003-feat", "contracts", "x.md"), "003-feat", "contracts/x.md", true},
+		{"outside specs", "README.md", "", "", false},
+		{"feature dir only (no file)", filepath.Join("specs", "003-feat"), "", "", false},
 	}
-	if err := os.WriteFile(filepath.Join(specifyDir, "feature.json"),
-		[]byte(`{"feature_directory":"specs/003-sdd-phase-orchestrator"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	dir, ok := resolveSddFeatureDir(repo)
-	if !ok {
-		t.Fatalf("expected to resolve feature dir")
-	}
-	if filepath.Base(dir) != "003-sdd-phase-orchestrator" {
-		t.Errorf("feature dir = %q, want it to end with the feature name", dir)
-	}
-
-	if _, ok := resolveSddFeatureDir(t.TempDir()); ok {
-		t.Errorf("a repo without .specify/feature.json must not resolve")
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			featureDir, featureRel, ok := deriveSddFeature(testCase.changed, repo)
+			if ok != testCase.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, testCase.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if filepath.Base(featureDir) != testCase.wantFeature || featureRel != testCase.wantRel {
+				t.Errorf("got (%q, %q), want feature %q rel %q", filepath.Base(featureDir), featureRel, testCase.wantFeature, testCase.wantRel)
+			}
+		})
 	}
 }
 
-func TestSddFeatureRel(t *testing.T) {
-	repo := t.TempDir() // a genuine absolute path (with a volume on Windows)
-	feature := filepath.Join(repo, "specs", "003-feat")
-
-	if rel, ok := sddFeatureRel(filepath.Join("specs", "003-feat", "spec.md"), repo, feature); !ok || rel != "spec.md" {
-		t.Errorf("repo-relative change = (%q, %v), want (spec.md, true)", rel, ok)
+func TestSameSddRepo(t *testing.T) {
+	cases := []struct {
+		left, right string
+		want        bool
+	}{
+		{"C:/a/b", "C:/a/b", true},
+		{"C:/a/b", "C:/a/b/", true},          // trailing slash tolerated
+		{`C:\a\b`, "C:/a/b", true},            // separator-insensitive
+		{"C:/A/B", "c:/a/b", true},            // case-insensitive (Windows)
+		{"C:/a/b", "C:/a/c", false},
 	}
-	if rel, ok := sddFeatureRel(filepath.Join(feature, "plan.md"), repo, feature); !ok || rel != "plan.md" {
-		t.Errorf("absolute change = (%q, %v), want (plan.md, true)", rel, ok)
-	}
-	if _, ok := sddFeatureRel(filepath.Join("README.md"), repo, feature); ok {
-		t.Errorf("a file outside the feature dir must be rejected")
+	for _, testCase := range cases {
+		if got := sameSddRepo(testCase.left, testCase.right); got != testCase.want {
+			t.Errorf("sameSddRepo(%q,%q) = %v, want %v", testCase.left, testCase.right, got, testCase.want)
+		}
 	}
 }
 
@@ -75,17 +84,46 @@ func TestSddGateEnvelope_FlattensWithType(t *testing.T) {
 	}
 }
 
-func TestHandleSddBind_Validation(t *testing.T) {
-	missing := httptest.NewRecorder()
-	handleSddBind(missing, httptest.NewRequest(http.MethodPost, "/api/sdd/bind", strings.NewReader(`{}`)))
-	if missing.Code != http.StatusBadRequest {
-		t.Errorf("missing fields status = %d, want 400", missing.Code)
+func TestHandleSddBind_RequiresFields(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handleSddBind(recorder, httptest.NewRequest(http.MethodPost, "/api/sdd/bind", strings.NewReader(`{}`)))
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("missing fields status = %d, want 400", recorder.Code)
+	}
+}
+
+// Eager bind: a session binds even when the repo has no .specify/feature.json yet (the feature
+// is learned lazily when an artifact appears). And re-binding the same repo is a no-op that
+// reuses the existing pipeline rather than replacing it (which would invalidate an open card).
+func TestHandleSddBind_EagerAndIdempotent(t *testing.T) {
+	repo := t.TempDir() // no .specify/feature.json — eager bind must still succeed
+	sessionID := "bind-test-session"
+	body := `{"sessionId":"` + sessionID + `","repoRoot":"` + strings.ReplaceAll(repo, `\`, `\\`) + `"}`
+
+	first := httptest.NewRecorder()
+	handleSddBind(first, httptest.NewRequest(http.MethodPost, "/api/sdd/bind", strings.NewReader(body)))
+	t.Cleanup(func() {
+		if pipeline, ok := sddPipelineFor(sessionID); ok {
+			pipeline.watcher.Stop()
+			sddPipelines.Delete(sessionID)
+		}
+	})
+	if first.Code != http.StatusOK || !strings.Contains(first.Body.String(), "bound") {
+		t.Fatalf("eager bind status = %d body = %s, want 200 bound", first.Code, first.Body.String())
+	}
+	pipelineOne, ok := sddPipelineFor(sessionID)
+	if !ok {
+		t.Fatalf("expected a pipeline registered for %s", sessionID)
 	}
 
-	noFeature := httptest.NewRecorder()
-	body := `{"sessionId":"s1","repoRoot":"` + strings.ReplaceAll(t.TempDir(), `\`, `\\`) + `"}`
-	handleSddBind(noFeature, httptest.NewRequest(http.MethodPost, "/api/sdd/bind", strings.NewReader(body)))
-	if noFeature.Code != http.StatusConflict {
-		t.Errorf("no-feature status = %d, want 409", noFeature.Code)
+	// Second identical bind must reuse the same pipeline (no replacement → no card invalidation).
+	second := httptest.NewRecorder()
+	handleSddBind(second, httptest.NewRequest(http.MethodPost, "/api/sdd/bind", strings.NewReader(body)))
+	if second.Code != http.StatusOK {
+		t.Fatalf("re-bind status = %d, want 200", second.Code)
+	}
+	pipelineTwo, _ := sddPipelineFor(sessionID)
+	if pipelineOne != pipelineTwo {
+		t.Errorf("re-binding the same repo must reuse the pipeline, not replace it")
 	}
 }

--- a/cypress/e2e/sdd-phase-gate.cy.js
+++ b/cypress/e2e/sdd-phase-gate.cy.js
@@ -81,4 +81,23 @@ describe('SDD phase orchestrator — in-terminal decision card', () => {
       expect(text).to.not.include(NEXT_COMMAND)
     })
   })
+
+  it('failsafe: the dismiss control always closes the card so the session is never trapped', () => {
+    cy.visit(`${DEV_URL}/`, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('tour_disabled', 'true')
+      },
+    })
+    cy.waitForTerminal()
+    cy.get('.new-tab-btn').click()
+    cy.waitForTerminal()
+    cy.wait(3000)
+
+    cy.exec(`powershell -NoProfile -Command "(Get-Item '${SPEC_FILE}').LastWriteTime = Get-Date"`)
+    cy.get('.phase-decision-card', { timeout: 15000 }).should('be.visible')
+
+    // The ✕ is the guaranteed local escape — it must close the card with no backend dependency.
+    cy.get('.phase-decision-card-dismiss').click()
+    cy.get('.phase-decision-card').should('not.exist')
+  })
 })

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2329,6 +2329,9 @@ function App() {
         summary={sddGate.card?.summary}
         actions={sddGate.card?.actions}
         onAction={(action, clarifyText) => sddGate.submitDecision(action, clarifyText)}
+        onDismiss={sddGate.dismiss}
+        decisionError={sddGate.decisionError}
+        isSubmitting={sddGate.isSubmitting}
       />
 
       <ToastContainer toasts={toasts} removeToast={removeToast} />

--- a/frontend/src/components/PhaseDecisionCard.css
+++ b/frontend/src/components/PhaseDecisionCard.css
@@ -31,6 +31,28 @@
   background: #141414;
 }
 
+/* Failsafe exit ✕ pinned to the right of the header. Subtle until hovered;
+   never disabled, so the user can always escape a stuck decision. */
+.phase-decision-card-dismiss {
+  margin-left: auto;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #8a8a8a;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.phase-decision-card-dismiss:hover {
+  background: #2a2a2a;
+  color: #f0f0f0;
+}
+
 .phase-decision-card-status {
   font-size: 0.72em;
   letter-spacing: 0.08em;
@@ -119,13 +141,57 @@
   color: #fca5a5;
 }
 
+/* Decision failure block: reuses the warn-severity color feel so a failed
+   POST is unmistakable, and reminds the user the card can be dismissed. */
+.phase-decision-card-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid #f59e0b;
+  border-radius: 6px;
+  background: #422006;
+  color: #fed7aa;
+}
+
+.phase-decision-card-error-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: #f59e0b;
+}
+
+.phase-decision-card-error-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.phase-decision-card-error-message {
+  font-size: 0.88em;
+  font-weight: 600;
+}
+
+.phase-decision-card-error-hint {
+  font-size: 0.8em;
+  color: #fdba74;
+}
+
 .phase-decision-card-actions {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   gap: 10px;
   padding: 14px 20px;
   border-top: 1px solid #333;
   background: #141414;
+}
+
+/* Subtle in-flight indicator pinned to the left of the action row. */
+.phase-decision-card-pending {
+  margin-right: auto;
+  font-size: 0.82em;
+  color: #9ca3af;
 }
 
 .phase-decision-card-button {
@@ -144,6 +210,17 @@
 
 .phase-decision-card-button:hover {
   border-color: #555;
+}
+
+/* Pending state: while a decision is in flight the action buttons are disabled
+   to prevent double-submits. Dismiss/Cancel are deliberately never disabled. */
+.phase-decision-card-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.phase-decision-card-button:disabled:hover {
+  border-color: #333;
 }
 
 .phase-decision-card-button-icon {

--- a/frontend/src/components/PhaseDecisionCard.jsx
+++ b/frontend/src/components/PhaseDecisionCard.jsx
@@ -1,7 +1,7 @@
 // Presentational decision card for an SDD (Spec Kit) phase gate: shows a scannable
 // summary of a completed phase and the actions a user can take to advance the pipeline.
-import React, { useCallback, useState } from 'react'
-import { CheckCircle2, XCircle, MessageSquare, FileText } from 'lucide-react'
+import React, { useCallback, useEffect, useState } from 'react'
+import { CheckCircle2, XCircle, MessageSquare, FileText, X, AlertTriangle } from 'lucide-react'
 
 import './PhaseDecisionCard.css'
 
@@ -31,8 +31,22 @@ const CLARIFY_PLACEHOLDER = 'Add a steer for the next phase…'
  * invokes `onAction(action)` with the backend action string. Clarify is a
  * two-step interaction: the first click opens an inline steer input, and
  * Confirm invokes `onAction('clarify', trimmedSteer)`.
+ *
+ * `onDismiss` is the failsafe exit: a header ✕ and the Escape key both call it,
+ * and it stays enabled regardless of backend state so the user is never trapped.
+ * `decisionError` (when set) renders a visible error block, and `isSubmitting`
+ * disables the action buttons while a decision is in flight.
  */
-export default function PhaseDecisionCard({ phase, summary, actions, onAction, isOpen }) {
+export default function PhaseDecisionCard({
+  phase,
+  summary,
+  actions,
+  onAction,
+  onDismiss,
+  decisionError,
+  isSubmitting,
+  isOpen,
+}) {
   // Whether the inline clarify steer input is showing instead of the action buttons.
   const [isClarifying, setIsClarifying] = useState(false)
   // The raw steer text the user is typing for a clarify action.
@@ -70,10 +84,22 @@ export default function PhaseDecisionCard({ phase, summary, actions, onAction, i
     [onAction, handleClarifyOpen]
   )
 
+  // Escape is a failsafe exit alongside the header ✕: while the card is open,
+  // pressing Escape dismisses it locally so a stuck backend can never trap the user.
+  useEffect(() => {
+    if (!isOpen) return undefined
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') onDismiss()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onDismiss])
+
   if (!isOpen) return null
 
   const { headline, producedItems = [], flags = [] } = summary ?? {}
   const hasClarifyText = clarifyText.trim().length > 0
+  const hasDecisionError = Boolean(decisionError)
 
   return (
     <div className="phase-decision-card-overlay">
@@ -81,6 +107,16 @@ export default function PhaseDecisionCard({ phase, summary, actions, onAction, i
         <div className="phase-decision-card-header">
           <span className="phase-decision-card-status">Phase Gate</span>
           <h3 className="phase-decision-card-phase">{phase}</h3>
+          {/* Failsafe exit: never disabled, no backend call — guaranteed escape. */}
+          <button
+            type="button"
+            className="phase-decision-card-dismiss"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            title="Dismiss (Esc)"
+          >
+            <X size={18} />
+          </button>
         </div>
 
         <div className="phase-decision-card-body">
@@ -116,6 +152,18 @@ export default function PhaseDecisionCard({ phase, summary, actions, onAction, i
               })
             )}
           </div>
+
+          {hasDecisionError && (
+            <div className="phase-decision-card-error" role="alert">
+              <AlertTriangle size={16} className="phase-decision-card-error-icon" />
+              <div className="phase-decision-card-error-text">
+                <span className="phase-decision-card-error-message">{decisionError}</span>
+                <span className="phase-decision-card-error-hint">
+                  Retry, or dismiss this card to continue.
+                </span>
+              </div>
+            </div>
+          )}
         </div>
 
         {isClarifying ? (
@@ -148,6 +196,11 @@ export default function PhaseDecisionCard({ phase, summary, actions, onAction, i
           </div>
         ) : (
           <div className="phase-decision-card-actions">
+            {isSubmitting && (
+              <span className="phase-decision-card-pending" aria-live="polite">
+                Submitting…
+              </span>
+            )}
             {actions.map((action) => {
               const presentation = ACTION_PRESENTATION[action] ?? { label: action, Icon: null }
               const { label, Icon } = presentation
@@ -157,6 +210,7 @@ export default function PhaseDecisionCard({ phase, summary, actions, onAction, i
                   type="button"
                   className={`phase-decision-card-button phase-decision-card-button-${action}`}
                   onClick={() => handleActionClick(action)}
+                  disabled={isSubmitting}
                 >
                   {Icon && <Icon size={16} className="phase-decision-card-button-icon" />}
                   {label}

--- a/frontend/src/components/PhaseDecisionCard.test.jsx
+++ b/frontend/src/components/PhaseDecisionCard.test.jsx
@@ -18,6 +18,9 @@ const renderCard = (overrides = {}) => {
     summary: buildSummary(),
     actions: ['approve', 'reject', 'clarify'],
     onAction: vi.fn(),
+    onDismiss: vi.fn(),
+    decisionError: null,
+    isSubmitting: false,
     isOpen: true,
     ...overrides,
   }
@@ -175,5 +178,36 @@ describe('PhaseDecisionCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /clarify/i }))
     expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('calls onDismiss (and not onAction) when the dismiss control is clicked', () => {
+    const { onAction, onDismiss } = renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('calls onDismiss when Escape is pressed', () => {
+    const { onDismiss } = renderCard()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the decision error and keeps the dismiss control enabled', () => {
+    renderCard({ decisionError: 'Decision request failed: 500' })
+
+    expect(screen.getByText(/decision request failed: 500/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeEnabled()
+  })
+
+  it('disables Approve but keeps Dismiss enabled while submitting', () => {
+    renderCard({ isSubmitting: true })
+
+    expect(screen.getByRole('button', { name: /approve/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeEnabled()
   })
 })

--- a/frontend/src/hooks/useSddGate.js
+++ b/frontend/src/hooks/useSddGate.js
@@ -12,13 +12,20 @@ const DECISION_ENDPOINT = '/api/sdd/decision'
  * useSddGate tracks the currently open SDD phase gate for `activeSessionId`.
  *
  * Returns `handleWsMessage(rawData)` to feed raw WebSocket strings in, the
- * current `card` plus `isCardOpen` flag for rendering, and `submitDecision`
- * to send a decision to the backend (clearing the card on success).
+ * current `card` plus `isCardOpen` flag for rendering, `submitDecision` to send
+ * a decision to the backend (clearing the card on success), and `dismiss` — a
+ * guaranteed local escape hatch that closes the card with no backend call so a
+ * failed decision can never trap the user. `decisionError` surfaces a failure
+ * message for the UI, and `isSubmitting` flags an in-flight POST.
  *
  * @param {{ activeSessionId: string }} params
  */
 export function useSddGate({ activeSessionId }) {
   const [card, setCard] = useState(null)
+  // A human-readable failure message from the last decision attempt, or null.
+  const [decisionError, setDecisionError] = useState(null)
+  // True only while a decision POST is in flight, so the UI can block double-clicks.
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleWsMessage = useCallback(
     (rawData) => {
@@ -33,15 +40,26 @@ export function useSddGate({ activeSessionId }) {
       if (parsed?.type !== SDD_PHASE_GATE_TYPE) return
       if (parsed.sessionId !== activeSessionId) return
 
+      // A fresh gate supersedes any stale failure from the previous one.
+      setDecisionError(null)
       setCard(parsed)
     },
     [activeSessionId]
   )
 
+  // dismiss is the failsafe exit: it clears the card locally with no backend
+  // call, so the user can always escape even when the backend is unreachable.
+  const dismiss = useCallback(() => {
+    setCard(null)
+    setDecisionError(null)
+    setIsSubmitting(false)
+  }, [])
+
   const submitDecision = useCallback(
     async (action, clarifyText) => {
       if (!card) return
 
+      setIsSubmitting(true)
       try {
         const response = await fetch(DECISION_ENDPOINT, {
           method: 'POST',
@@ -60,10 +78,16 @@ export function useSddGate({ activeSessionId }) {
           throw new Error(`Decision request failed: ${response.status}`)
         }
 
-        // Success: the gate is resolved, so dismiss the card.
+        // Success: the gate is resolved, so dismiss the card and clear any error.
+        setDecisionError(null)
         setCard(null)
-      } catch (decisionError) {
-        console.error('Failed to submit SDD decision:', decisionError)
+      } catch (caughtError) {
+        // Failure: keep the card open so the user can retry or dismiss, and
+        // surface a short message (with the status when present).
+        console.error('Failed to submit SDD decision:', caughtError)
+        setDecisionError(caughtError.message ?? 'Decision request failed')
+      } finally {
+        setIsSubmitting(false)
       }
     },
     [card]
@@ -72,7 +96,10 @@ export function useSddGate({ activeSessionId }) {
   return {
     card,
     isCardOpen: card !== null,
+    decisionError,
+    isSubmitting,
     handleWsMessage,
     submitDecision,
+    dismiss,
   }
 }

--- a/frontend/src/hooks/useSddGate.test.js
+++ b/frontend/src/hooks/useSddGate.test.js
@@ -140,4 +140,91 @@ describe('useSddGate', () => {
 
     expect(result.current.isCardOpen).toBe(true)
   })
+
+  it('dismiss() clears the card locally with no fetch call', () => {
+    const fetchSpy = vi.spyOn(global, 'fetch')
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage())
+    })
+    expect(result.current.isCardOpen).toBe(true)
+
+    act(() => {
+      result.current.dismiss()
+    })
+
+    expect(result.current.isCardOpen).toBe(false)
+    expect(result.current.card).toBeNull()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('on a 500 sets decisionError, keeps the card open, and clears isSubmitting', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 500 })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage())
+    })
+
+    await act(async () => {
+      await result.current.submitDecision('approve')
+    })
+
+    expect(result.current.isCardOpen).toBe(true)
+    expect(result.current.decisionError).toEqual(expect.stringContaining('500'))
+    expect(result.current.isSubmitting).toBe(false)
+  })
+
+  it('clears decisionError and the card on a successful decision', async () => {
+    // First fail to populate decisionError, then succeed.
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage())
+    })
+
+    await act(async () => {
+      await result.current.submitDecision('approve')
+    })
+    expect(result.current.decisionError).not.toBeNull()
+
+    await act(async () => {
+      await result.current.submitDecision('approve')
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(result.current.isCardOpen).toBe(false))
+    expect(result.current.card).toBeNull()
+    expect(result.current.decisionError).toBeNull()
+  })
+
+  it('clears a prior decisionError when a new SDD_PHASE_GATE arrives', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 500 })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage())
+    })
+
+    await act(async () => {
+      await result.current.submitDecision('approve')
+    })
+    expect(result.current.decisionError).not.toBeNull()
+
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage({ cardId: 'gate-plan-next' }))
+    })
+
+    expect(result.current.decisionError).toBeNull()
+    expect(result.current.isCardOpen).toBe(true)
+  })
 })

--- a/internal/sdd/orchestrator.go
+++ b/internal/sdd/orchestrator.go
@@ -102,6 +102,16 @@ func (o *Orchestrator) BindSession(sessionID string) {
 	o.mu.Unlock()
 }
 
+// SetFeatureDir points the orchestrator at the feature directory whose artifacts it should
+// summarize. This supports eager-bind/lazy-watch: a pipeline can be bound to a repo before any
+// feature exists, then have its feature directory set the moment the watcher detects the first
+// phase artifact (and re-set if the developer later moves on to a new feature).
+func (o *Orchestrator) SetFeatureDir(featureDir string) {
+	o.mu.Lock()
+	o.state.FeatureDir = featureDir
+	o.mu.Unlock()
+}
+
 // State returns a snapshot of the current pipeline state (for the HTTP layer and tests).
 func (o *Orchestrator) State() PipelineState {
 	o.mu.Lock()

--- a/internal/sdd/orchestrator_test.go
+++ b/internal/sdd/orchestrator_test.go
@@ -197,6 +197,18 @@ func TestSubmitDecision_AdvanceToPtyQuietPhaseGatesAfterWait(t *testing.T) {
 	}
 }
 
+func TestSetFeatureDir_UpdatesStateForLazyActivation(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+
+	if orchestrator.State().FeatureDir != "" {
+		t.Fatalf("expected empty feature dir before lazy activation, got %q", orchestrator.State().FeatureDir)
+	}
+	orchestrator.SetFeatureDir("specs/003-demo")
+	if got := orchestrator.State().FeatureDir; got != "specs/003-demo" {
+		t.Errorf("feature dir = %q, want specs/003-demo after SetFeatureDir", got)
+	}
+}
+
 func TestSubmitDecision_RecordsHistory(t *testing.T) {
 	orchestrator, _, _ := newTestOrchestrator(t)
 	orchestrator.HandlePhaseComplete(PhasePlan, "plan.md")


### PR DESCRIPTION
## The problem (reported from live use on v7.17.0)

The SDD phase decision cards were nearly unusable in real sessions, and one failure mode **trapped the user** (Approve did nothing; the only escape was killing the terminal). Three root causes:

1. **No failsafe exit.** A failed decision — e.g. a stale `cardId` after a re-bind — left the card open with no way to close it. `submitDecision` only `console.error`d; the card had no dismiss control. The decision endpoint also hard-`409`d on `cardId` mismatch, which is what made Approve silently fail.
2. **Activation by luck.** Binding fired once per `(tab, cwd)` and the backend `409`d when `.specify/feature.json` didn't exist yet — but you *create* the feature by running `/speckit-specify` during the session, after binding already gave up. So the card usually never fired.
3. **Single global orchestrator.** Multiple tabs clobbered one pipeline; a re-bind replaced it and invalidated the on-screen card's `cardId` (cause of #1's stale-card 409).

## The fix

- **Failsafe (frontend):** always-available dismiss (✕ / `Escape`) that closes the card locally with no backend call; inline error surfacing; buttons disabled while submitting. **Backend:** the decision endpoint is lenient — a stale `cardId`/phase is applied to the on-screen pending card, never rejected.
- **Eager bind / lazy watch:** a session binds to its repo with no feature required; the watcher learns the active feature from the first artifact (`specs/<feature>/…`), so the card fires the moment you run `/speckit-specify`.
- **Per-session pipelines:** a registry keyed by session id; tabs gate independently; re-binding the same repo is a no-op that doesn't invalidate an open card.

## Verification (live, against a running build)

- Eager bind on a **feature-less** repo → `200 bound` (was `409`).
- Create the feature *after* bind → watcher detects → a card fires (decision returns `200`, not `409 no-pending-card`).
- Decision with a **stale cardId** → `200` (lenient, no trap).
- Cypress (3/3): card renders, Approve injects the next command, Reject stops, and the **✕ dismiss always closes the card**.
- Unit/component: Go `internal/sdd` + `cmd/forge` green & vet-clean; frontend vitest 335 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)