### PR TITLE
fix: five SDD dashboard post-v7.19.0 UX defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **SDD Dashboard — decision bar bleeds across tabs** — switching tabs did not clear the current gate card; if a speckit gate fired in Tab A and the user switched to Tab B, Tab B showed the Approve/Reject/Clarify bar even though no speckit commands had run in that session; `useSddGate` now resets `card`, `decisionError`, and `isSubmitting` whenever `activeSessionId` changes
 - **SDD Dashboard — `SDD_PHASE_STATUS` events never reached `useSddGate`** — `ForgeTerminal.jsx` only routed `SDD_PHASE_GATE` to `onSddGateRef`; `SDD_PHASE_STATUS` messages fell through to terminal output, so phase statuses were frozen at the one-time recovery fetch value and never updated live; fixed by also routing `SDD_PHASE_STATUS` in the same guard (`msg.type === 'SDD_PHASE_GATE' || msg.type === 'SDD_PHASE_STATUS'`)
 - **SDD Dashboard — decision bar lost after page reload** — `GET /api/sdd/status` only returned phase statuses, never the pending card; after a reload the card was null so the decision bar was hidden even though a gate was open; the endpoint now includes `pendingCard` when one exists and `useSddGate` restores it on mount
 - **SDD Dashboard — idle rail invisible** — `.sdd-dashboard__rail-wrapper` used `flex: 1` inside an unconstrained flex-column parent, collapsing the rail to 0 height; fixed with `min-height: 44px`; idle-row text color raised from `#4a4a4a` (near-black-on-black) to `#6b7280`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD Dashboard — `SDD_PHASE_STATUS` events never reached `useSddGate`** — `ForgeTerminal.jsx` only routed `SDD_PHASE_GATE` to `onSddGateRef`; `SDD_PHASE_STATUS` messages fell through to terminal output, so phase statuses were frozen at the one-time recovery fetch value and never updated live; fixed by also routing `SDD_PHASE_STATUS` in the same guard (`msg.type === 'SDD_PHASE_GATE' || msg.type === 'SDD_PHASE_STATUS'`)
+- **SDD Dashboard — decision bar lost after page reload** — `GET /api/sdd/status` only returned phase statuses, never the pending card; after a reload the card was null so the decision bar was hidden even though a gate was open; the endpoint now includes `pendingCard` when one exists and `useSddGate` restores it on mount
+- **SDD Dashboard — idle rail invisible** — `.sdd-dashboard__rail-wrapper` used `flex: 1` inside an unconstrained flex-column parent, collapsing the rail to 0 height; fixed with `min-height: 44px`; idle-row text color raised from `#4a4a4a` (near-black-on-black) to `#6b7280`
+- **ActionPromptStrip gate-open prompt** — text "Review the artifact above…" referenced an inline artifact preview that was removed in spec-006; replaced with "Approve to continue, Reject to restart this phase, or Clarify to redirect."
+
 ## [7.19.0] - 2026-06-18
 
 ---

--- a/cmd/forge/handlers_sdd.go
+++ b/cmd/forge/handlers_sdd.go
@@ -97,11 +97,17 @@ func handleSddStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	state := pipeline.orchestrator.State()
-	writeSddJSON(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"sessionId": sessionID,
 		"feature":   filepath.Base(state.FeatureDir),
 		"phases":    buildPhaseStatuses(pipeline),
-	})
+	}
+	// Include the pending card so the frontend can restore the decision bar after a
+	// page reload — SDD_PHASE_GATE events are not replayed on reconnect (FR-012).
+	if state.PendingCard != nil {
+		response["pendingCard"] = state.PendingCard
+	}
+	writeSddJSON(w, http.StatusOK, response)
 }
 
 // writeSddDecisionError maps orchestrator errors to precise HTTP status codes.

--- a/frontend/src/components/ActionPromptStrip.jsx
+++ b/frontend/src/components/ActionPromptStrip.jsx
@@ -6,7 +6,7 @@ import './ActionPromptStrip.css'
 // Named prompt constants — one per priority-ordered condition (data-model.md).
 const PROMPT_COMPLETE    = 'Pipeline complete.'
 const PROMPT_ITERATING   = 'Approve this iteration, or Reject to try again.'
-const PROMPT_FIRST_GATE  = 'Review the artifact above, then Approve, Reject, or Clarify.'
+const PROMPT_FIRST_GATE  = 'Approve to continue, Reject to restart this phase, or Clarify to redirect.'
 const PROMPT_RUNNING     = (phase) => `${capitalise(phase)} is running…`
 export const PROMPT_UNKNOWN = 'Unexpected pipeline state. Check the terminal.'
 

--- a/frontend/src/components/ActionPromptStrip.test.jsx
+++ b/frontend/src/components/ActionPromptStrip.test.jsx
@@ -33,7 +33,7 @@ describe('deriveActionPrompt', () => {
   it('returns first-run prompt when card is open and no iterating phase', () => {
     const phases = makePhases({ specify: 'awaiting-decision' })
     expect(deriveActionPrompt(phases, true)).toBe(
-      'Review the artifact above, then Approve, Reject, or Clarify.'
+      'Approve to continue, Reject to restart this phase, or Clarify to redirect.'
     )
   })
 

--- a/frontend/src/components/ForgeTerminal.jsx
+++ b/frontend/src/components/ForgeTerminal.jsx
@@ -1881,9 +1881,9 @@ const ForgeTerminal = forwardRef(function ForgeTerminal({
             try {
               const msg = JSON.parse(str);
 
-              // SDD orchestrator (specs/003): surface phase-gate messages to the in-app
-              // decision card and stop — this message is not terminal output.
-              if (msg.type === 'SDD_PHASE_GATE') {
+              // SDD orchestrator (specs/003, 006): surface gate and live-status messages to
+              // the dashboard hook and stop — these are not terminal output.
+              if (msg.type === 'SDD_PHASE_GATE' || msg.type === 'SDD_PHASE_STATUS') {
                 if (onSddGateRef.current) onSddGateRef.current(str);
                 return;
               }

--- a/frontend/src/components/SddDashboard.css
+++ b/frontend/src/components/SddDashboard.css
@@ -64,6 +64,9 @@
 .sdd-dashboard__rail-wrapper {
   position: relative;
   flex: 1;
+  /* min-height prevents the rail from collapsing to 0 in a flex-column parent
+     that has no explicit height (flex:1 on an unconstrained parent = 0px). */
+  min-height: 44px;
 }
 
 /* ── Phase rail — horizontal flex row of phase cells ──────────────────────── */
@@ -82,7 +85,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #4a4a4a;
+  color: #6b7280;
   font-size: 0.9em;
   padding: 4px 0;
 }

--- a/frontend/src/hooks/useSddGate.js
+++ b/frontend/src/hooks/useSddGate.js
@@ -58,6 +58,12 @@ export function useSddGate({ activeSessionId }) {
       .then((data) => {
         if (data?.phases?.length) setPhaseStatuses(data.phases)
         if (data?.feature) setFeatureName(data.feature)
+        // Restore a pending gate card after page reload. SDD_PHASE_GATE events are
+        // not replayed on reconnect, so the status endpoint includes the pending card
+        // when one exists so the decision bar reappears without a new WS event.
+        if (data?.pendingCard) {
+          setCard({ type: 'SDD_PHASE_GATE', ...data.pendingCard })
+        }
       })
       .catch(() => {}) // best-effort; WS events are the live source
   }, [activeSessionId])

--- a/frontend/src/hooks/useSddGate.js
+++ b/frontend/src/hooks/useSddGate.js
@@ -48,7 +48,12 @@ export function useSddGate({ activeSessionId }) {
   // WebSocket SDD_PHASE_STATUS events maintain live state thereafter.
   useEffect(() => {
     if (!activeSessionId) return
-    // Reset feature name and summaries when the session changes.
+    // Reset ALL session-scoped gate state when the active session changes.
+    // card belongs to a specific session — leaving it set when switching tabs
+    // causes the previous session's gate to appear in the new session's view.
+    setCard(null)
+    setDecisionError(null)
+    setIsSubmitting(false)
     setFeatureName('')
     phaseSummaries.current = {}
     fetch(`${STATUS_ENDPOINT}?sessionId=${encodeURIComponent(activeSessionId)}`, {

--- a/frontend/src/hooks/useSddGate.test.js
+++ b/frontend/src/hooks/useSddGate.test.js
@@ -249,6 +249,37 @@ const buildStatusMessage = (overrides = {}) =>
     ...overrides,
   })
 
+// ── Tab-switch isolation (Bug 4 root-cause fix) ───────────────────────────────
+
+describe('useSddGate — card isolation on session change', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('clears the card when activeSessionId changes (prevents cross-tab gate bleed)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false })
+
+    const OTHER_SESSION_ID = 'tab-9-other'
+    const { result, rerender } = renderHook(
+      ({ sid }) => useSddGate({ activeSessionId: sid }),
+      { initialProps: { sid: ACTIVE_SESSION_ID } }
+    )
+
+    // Open a gate on the first session.
+    act(() => {
+      result.current.handleWsMessage(buildGateMessage())
+    })
+    expect(result.current.isCardOpen).toBe(true)
+
+    // Simulate switching to a different tab (session change).
+    rerender({ sid: OTHER_SESSION_ID })
+
+    // Card must be cleared immediately so the new tab starts gate-free.
+    expect(result.current.isCardOpen).toBe(false)
+    expect(result.current.card).toBeNull()
+  })
+})
+
 // ── Card recovery from status endpoint (post-spec-006 bug fix) ───────────────
 
 describe('useSddGate — pendingCard recovery', () => {

--- a/frontend/src/hooks/useSddGate.test.js
+++ b/frontend/src/hooks/useSddGate.test.js
@@ -249,6 +249,48 @@ const buildStatusMessage = (overrides = {}) =>
     ...overrides,
   })
 
+// ── Card recovery from status endpoint (post-spec-006 bug fix) ───────────────
+
+describe('useSddGate — pendingCard recovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('restores an open card when the recovery fetch returns pendingCard', async () => {
+    const pendingCard = {
+      cardId:  'gate-specify-999',
+      sessionId: ACTIVE_SESSION_ID,
+      phase:   'specify',
+      summary: { headline: 'Spec done', producedItems: ['spec.md'], flags: [] },
+      actions: ['approve', 'reject', 'clarify'],
+    }
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ phases: [], feature: '', pendingCard }),
+    })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    await waitFor(() => expect(result.current.isCardOpen).toBe(true))
+    expect(result.current.card).toMatchObject({ phase: 'specify', cardId: 'gate-specify-999' })
+  })
+
+  it('does not restore a card when pendingCard is absent from the recovery fetch', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ phases: [], feature: '' }),
+    })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    // Give the fetch time to resolve.
+    await act(async () => {})
+    expect(result.current.isCardOpen).toBe(false)
+  })
+})
+
+// ── T002: featureName and phaseSummaries (spec-006) ─────────────────────────
+
 describe('useSddGate — featureName (spec-006)', () => {
   beforeEach(() => {
     vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false })


### PR DESCRIPTION
## Summary

Five production bugs found after v7.19.0 shipped the SDD Dashboard (spec-006):

- **Bug 5 (cross-tab gate bleed)**: Switching tabs did not reset the gate card — a `SDD_PHASE_GATE` that fired in Tab A would show Approve/Reject/Clarify in Tab B even though no speckit commands ran there. `useSddGate` now resets `card`, `decisionError`, and `isSubmitting` whenever `activeSessionId` changes.
- **Bug 2 (`SDD_PHASE_STATUS` discarded)**: `ForgeTerminal.jsx` only routed `SDD_PHASE_GATE` to `onSddGateRef`; live status updates fell through to terminal output; phase rail was frozen at recovery-fetch values and never showed a running phase as active.
- **Bug 2b (card lost on reload)**: `GET /api/sdd/status` never included the pending card; after a page reload the decision bar vanished even when a gate was still open. Endpoint now returns `pendingCard` when one exists; hook restores it on mount.
- **Bug 3 (idle rail invisible)**: `flex: 1` inside an unconstrained flex-column collapsed the rail to 0px; idle text was near-black-on-black (`#4a4a4a`). Fixed with `min-height: 44px` and color `#6b7280`.
- **Bug 1 (wrong action prompt)**: "Review the artifact above…" referenced the inline artifact preview removed in spec-006. New text: "Approve to continue, Reject to restart this phase, or Clarify to redirect."

## Test plan

- [x] `npx vitest run` — 366 frontend tests pass (1 new: card isolation on session change)
- [x] `go test ./...` — all Go tests pass
- [x] Pre-push hook passed (Go build + test + frontend test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111i2hnheWYxAT4qLVrhqxX