### PR TITLE
fix: SDD Dashboard artifact link resolves to absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD Dashboard — artifact "File not found" on click** — `buildPhaseStatuses` sent `ArtifactPath` as a feature-relative filename (e.g. `"spec.md"`) instead of the absolute path; the frontend resolved it against the working directory and failed when the spec kit writes artifacts to a subdirectory (`specs/<feature>/spec.md`); `ArtifactPath` is now `filepath.Join(state.FeatureDir, phase.ExpectedArtifact)`, matching the path construction already used by the `SDD_PHASE_GATE` broadcaster; phases with no artifact (Validate, Implement) continue to emit an empty string
+
 ## [7.19.1] - 2026-06-18
 
 ---

--- a/cmd/forge/sdd_wiring.go
+++ b/cmd/forge/sdd_wiring.go
@@ -333,11 +333,18 @@ func buildPhaseStatuses(pipeline *sddPipeline) []sdd.PhaseStatusEntry {
 	for _, phase := range phases {
 		runCount := pipeline.orchestrator.PhaseRunCount(phase.Name)
 		displayStatus := derivePhaseDisplayStatus(phase.Order, currentOrder, state.Status, runCount)
+		// Build the absolute artifact path so the frontend can open the file
+		// directly. Phases with no artifact (Validate, Implement) keep an empty
+		// string; filepath.Join(dir, "") would return dir, not a file.
+		artifactPath := ""
+		if phase.ExpectedArtifact != "" {
+			artifactPath = filepath.Join(state.FeatureDir, phase.ExpectedArtifact)
+		}
 		entries = append(entries, sdd.PhaseStatusEntry{
 			Phase:         phase.Name,
 			Order:         phase.Order,
 			DisplayStatus: displayStatus,
-			ArtifactPath:  phase.ExpectedArtifact,
+			ArtifactPath:  artifactPath,
 			DecidedAt:     nil,
 			RunCount:      runCount,
 		})

--- a/cmd/forge/sdd_wiring_test.go
+++ b/cmd/forge/sdd_wiring_test.go
@@ -185,6 +185,52 @@ func TestBuildPhaseStatuses_PhaseRejected_PipelineStopped(t *testing.T) {
 	}
 }
 
+func TestBuildPhaseStatuses_ArtifactPaths_AbsoluteWhenFeatureDirSet(t *testing.T) {
+	pipeline := newTestPipeline(t, "artifact-path-sess")
+	featureDir := filepath.Join(t.TempDir(), "specs", "007-my-feature")
+	pipeline.orchestrator.SetFeatureDir(featureDir)
+
+	statuses := buildPhaseStatuses(pipeline)
+
+	// Phases that produce a file artifact must carry the absolute path so the
+	// frontend can open the file without resolving against the working directory.
+	wantArtifactPaths := map[sdd.PhaseName]string{
+		sdd.PhaseSpecify:       filepath.Join(featureDir, "spec.md"),
+		sdd.PhaseClarify:       filepath.Join(featureDir, "spec.md"),
+		sdd.PhasePlan:          filepath.Join(featureDir, "plan.md"),
+		sdd.PhaseTasksGenerate: filepath.Join(featureDir, "tasks.md"),
+		sdd.PhaseValidate:      "",
+		sdd.PhaseImplement:     "",
+	}
+	for _, entry := range statuses {
+		want, isDefined := wantArtifactPaths[entry.Phase]
+		if !isDefined {
+			t.Errorf("unexpected phase %s in statuses", entry.Phase)
+			continue
+		}
+		if entry.ArtifactPath != want {
+			t.Errorf("phase %s: ArtifactPath = %q, want %q", entry.Phase, entry.ArtifactPath, want)
+		}
+	}
+}
+
+func TestBuildPhaseStatuses_ArtifactPaths_EmptyForNoArtifactPhases(t *testing.T) {
+	pipeline := newTestPipeline(t, "no-artifact-sess")
+	pipeline.orchestrator.SetFeatureDir(filepath.Join(t.TempDir(), "specs", "007-no-art"))
+
+	statuses := buildPhaseStatuses(pipeline)
+
+	noArtifactPhases := map[sdd.PhaseName]bool{
+		sdd.PhaseValidate:  true,
+		sdd.PhaseImplement: true,
+	}
+	for _, entry := range statuses {
+		if noArtifactPhases[entry.Phase] && entry.ArtifactPath != "" {
+			t.Errorf("phase %s: expected empty ArtifactPath for no-artifact phase, got %q", entry.Phase, entry.ArtifactPath)
+		}
+	}
+}
+
 // --- end T016 ---
 
 // --- T005: derivePhaseDisplayStatus run-count tests (Red until T006 adds runCount param) ---


### PR DESCRIPTION
## Summary

- `buildPhaseStatuses` was sending `ArtifactPath` as a feature-relative filename (e.g. `"spec.md"`) instead of an absolute path
- The frontend resolved it against the working directory and showed **"File not found: spec.md (looked in C:\…\AzureWorkflowPOC)"** when the user clicked a phase artifact link
- Fix: `filepath.Join(state.FeatureDir, phase.ExpectedArtifact)` — the same join already used by the `SDD_PHASE_GATE` broadcaster at line 298
- Phases with no artifact (`Validate`, `Implement`) continue to emit `""`

## Test plan

- [x] `TestBuildPhaseStatuses_ArtifactPaths_AbsoluteWhenFeatureDirSet` — verifies all artifact-producing phases emit the joined absolute path
- [x] `TestBuildPhaseStatuses_ArtifactPaths_EmptyForNoArtifactPhases` — verifies no-artifact phases always emit `""`
- [x] All existing `TestBuildPhaseStatuses_*` tests continue to pass
- [x] `go build ./cmd/forge/` clean
- [x] Pre-push gate: Go build + Go tests + frontend tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)