### PR TITLE
fix: SDD gate timing — active spinner + no premature card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD gate — premature card while agent still running** — `gateSddArtifact` previously called `HandlePhaseComplete` the instant the filesystem watcher detected an artifact file, causing the decision card to appear while the agent was still generating output or awaiting a permission prompt; the call now fires only after PTY-quiet detection (reusing `sddPhaseFloorMs` / `sddPhaseQuietMs` / `sddPhaseMaxMs`), consistent with how Validate and Implement have always worked
+- **SDD pipeline panel — no spinner while phase is running** — artifact-detected phases (Specify, Clarify, Plan, Tasks) showed as `pending` with a "Run /speckit-… to continue" prompt while actively running; a new `StatusRunning` pipeline state is set by `MarkPhaseRunning` the moment an artifact is first detected, causing `derivePhaseDisplayStatus` to return `PhaseDisplayActive` and the UI to show the blue spinning indicator; the state automatically transitions to `awaiting-decision` once PTY-quiet is detected
+
 ## [7.19.3] - 2026-06-19
 
 ---

--- a/cmd/forge/sdd_wiring.go
+++ b/cmd/forge/sdd_wiring.go
@@ -190,10 +190,12 @@ func runSddDetector(pipeline *sddPipeline, sessionID string) {
 	}
 }
 
-// gateSddArtifact classifies one changed file and, if it is a phase artifact, points the
-// orchestrator at the feature it belongs to and fires the completion seam. The feature directory
-// is derived from the artifact's own path (specs/<feature>/…), so no .specify/feature.json is
-// required and switching to a new feature later "just works".
+// gateSddArtifact classifies one changed file and, if it is a phase artifact, drives the
+// two-step completion: (1) immediately marks the phase as running so the UI spinner appears,
+// (2) waits for PTY silence on a goroutine before firing the completion seam to open the gate.
+// This prevents the decision card from appearing while the agent is still writing output or
+// awaiting a permission prompt. Duplicate watcher fires for an already-running phase are
+// suppressed by MarkPhaseRunning returning false.
 func gateSddArtifact(pipeline *sddPipeline, sessionID, changedPath string) {
 	featureDir, featureRel, ok := deriveSddFeature(changedPath, pipeline.repoRoot)
 	if !ok {
@@ -209,7 +211,39 @@ func gateSddArtifact(pipeline *sddPipeline, sessionID, changedPath string) {
 	}
 	pipeline.orchestrator.BindSession(sessionID)
 	pipeline.orchestrator.SetFeatureDir(featureDir)
-	pipeline.orchestrator.HandlePhaseComplete(phase, featureRel)
+
+	// Step 1 — mark running immediately so the UI spinner appears before the gate opens.
+	// Returns false when the gate is already open (duplicate watcher fire) or the pipeline is
+	// complete; skip in those cases to avoid corrupting orchestrator state.
+	if !pipeline.orchestrator.MarkPhaseRunning(phase) {
+		return
+	}
+	broadcastPhaseStatus(sessionID)
+
+	// Step 2 — wait for PTY silence, then open the gate. The goroutine is the sole writer
+	// of the HandlePhaseComplete transition out of StatusRunning for this phase, so there is
+	// no concurrent completion race to guard against.
+	go func() {
+		settleArtifactPhase(sessionID)
+		pipeline.orchestrator.HandlePhaseComplete(phase, featureRel)
+	}()
+}
+
+// settleArtifactPhase blocks until the terminal goes quiet after an artifact-detected phase
+// finishes writing, using the same floor/quiet/max constants as the PTY-quiet phases
+// (Validate, Implement). This makes gate-open timing consistent across all pipeline phases
+// regardless of their completion signal type.
+func settleArtifactPhase(sessionID string) {
+	if termHandler == nil {
+		return
+	}
+	session, found := termHandler.GetSession(sessionID)
+	if !found {
+		return
+	}
+	startedAt := time.Now()
+	time.Sleep(time.Duration(sddPhaseFloorMs) * time.Millisecond)
+	waitForPTYQuiet(session, sddPhaseQuietMs, sddPhaseMaxMs, startedAt, time.Now())
 }
 
 // deriveSddFeature splits a changed file path into the feature directory it belongs to and the
@@ -367,6 +401,10 @@ func derivePhaseDisplayStatus(phaseOrder, currentOrder int, pipelineStatus sdd.P
 
 	case phaseOrder == currentOrder:
 		switch pipelineStatus {
+		case sdd.StatusRunning:
+			// Artifact detected; waiting for the terminal to go quiet before opening the gate.
+			// The UI shows the active spinner while settlement is pending.
+			return sdd.PhaseDisplayActive
 		case sdd.StatusAwaitingDecision:
 			// Re-run: runCount ≥ 2 means the gate has opened at least twice.
 			if runCount >= 2 {

--- a/cmd/forge/sdd_wiring_test.go
+++ b/cmd/forge/sdd_wiring_test.go
@@ -255,6 +255,38 @@ func TestDerivePhaseDisplayStatus_AwaitingDecisionWhenRunCount1(t *testing.T) {
 	}
 }
 
+func TestDerivePhaseDisplayStatus_RunningCurrentPhaseIsActive(t *testing.T) {
+	// phaseOrder == currentOrder, status == StatusRunning → active (spinner shown while the
+	// terminal is still producing output, before the decision gate opens).
+	got := derivePhaseDisplayStatus(1, 1, sdd.StatusRunning, 0)
+	if got != sdd.PhaseDisplayActive {
+		t.Errorf("StatusRunning current phase → got %q, want active", got)
+	}
+}
+
+func TestBuildPhaseStatuses_PhaseRunning_ShowsActiveSpinner(t *testing.T) {
+	pipeline := newTestPipeline(t, "running-sess")
+	// Simulate artifact detected but terminal not yet settled (what gateSddArtifact does
+	// synchronously before launching the settlement goroutine).
+	pipeline.orchestrator.MarkPhaseRunning(sdd.PhaseSpecify)
+
+	statuses := buildPhaseStatuses(pipeline)
+
+	for _, entry := range statuses {
+		switch entry.Phase {
+		case sdd.PhaseSpecify:
+			if entry.DisplayStatus != sdd.PhaseDisplayActive {
+				t.Errorf("specify: got %q, want active while running", entry.DisplayStatus)
+			}
+		default:
+			// All phases after specify must remain pending.
+			if entry.DisplayStatus != sdd.PhaseDisplayPending {
+				t.Errorf("phase %s: got %q, want pending (should not advance until specify settles)", entry.Phase, entry.DisplayStatus)
+			}
+		}
+	}
+}
+
 func TestDerivePhaseDisplayStatus_ExistingCasesUnchanged(t *testing.T) {
 	// Existing behaviour (no phases started, phase before current, rejected) must be unaffected.
 	cases := []struct {

--- a/internal/sdd/orchestrator.go
+++ b/internal/sdd/orchestrator.go
@@ -106,6 +106,25 @@ func (o *Orchestrator) BindSession(sessionID string) {
 	o.mu.Unlock()
 }
 
+// MarkPhaseRunning transitions the pipeline to StatusRunning for the given phase, signalling
+// that the phase artifact has been detected but the terminal has not yet gone quiet. The UI
+// shows the active spinner while the pipeline is in this state; the decision gate has not
+// opened yet. Returns true if the transition was applied, or false when the pipeline is already
+// awaiting a decision, already running any phase, or complete — all of which mean the caller
+// must not launch a settlement goroutine (either a duplicate watcher fire or an illegal
+// out-of-order event).
+func (o *Orchestrator) MarkPhaseRunning(phase PhaseName) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	switch o.state.Status {
+	case StatusAwaitingDecision, StatusRunning, StatusComplete:
+		return false
+	}
+	o.state.CurrentPhase = phase
+	o.state.Status = StatusRunning
+	return true
+}
+
 // SetFeatureDir points the orchestrator at the feature directory whose artifacts it should
 // summarize. This supports eager-bind/lazy-watch: a pipeline can be bound to a repo before any
 // feature exists, then have its feature directory set the moment the watcher detects the first

--- a/internal/sdd/orchestrator_test.go
+++ b/internal/sdd/orchestrator_test.go
@@ -245,6 +245,70 @@ func TestPhaseRunCount_IndependentPerPhase(t *testing.T) {
 	}
 }
 
+func TestMarkPhaseRunning_TransitionsFromIdleToRunning(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+
+	wasTransitioned := orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if !wasTransitioned {
+		t.Fatal("MarkPhaseRunning should return true when transitioning from idle")
+	}
+	state := orchestrator.State()
+	if state.Status != StatusRunning {
+		t.Errorf("status = %q, want running", state.Status)
+	}
+	if state.CurrentPhase != PhaseSpecify {
+		t.Errorf("CurrentPhase = %q, want specify", state.CurrentPhase)
+	}
+}
+
+func TestMarkPhaseRunning_IdempotentWhenAlreadyRunning(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	// Duplicate watcher fire for the same (or any) phase must be suppressed.
+	wasTransitioned := orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if wasTransitioned {
+		t.Fatal("MarkPhaseRunning should return false when pipeline is already in StatusRunning")
+	}
+	if orchestrator.State().Status != StatusRunning {
+		t.Errorf("status must remain running, got %q", orchestrator.State().Status)
+	}
+}
+
+func TestMarkPhaseRunning_SuppressedWhenAwaitingDecision(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	// Drive orchestrator to AwaitingDecision via the normal completion seam.
+	orchestrator.HandlePhaseComplete(PhaseSpecify, "spec.md")
+
+	wasTransitioned := orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if wasTransitioned {
+		t.Fatal("MarkPhaseRunning should return false when a gate card is already open")
+	}
+	if orchestrator.State().Status != StatusAwaitingDecision {
+		t.Errorf("gate-open status must not be overwritten, got %q", orchestrator.State().Status)
+	}
+}
+
+func TestMarkPhaseRunning_SuppressedWhenPipelineComplete(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	orchestrator.HandlePhaseComplete(PhaseImplement, "")
+	if _, err := orchestrator.SubmitDecision(Decision{Phase: PhaseImplement, Action: ActionApprove}); err != nil {
+		t.Fatalf("approve terminal phase: %v", err)
+	}
+
+	wasTransitioned := orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if wasTransitioned {
+		t.Fatal("MarkPhaseRunning should return false when pipeline is complete")
+	}
+	if orchestrator.State().Status != StatusComplete {
+		t.Errorf("complete status must not be overwritten, got %q", orchestrator.State().Status)
+	}
+}
+
 func TestSetFeatureDir_UpdatesStateForLazyActivation(t *testing.T) {
 	orchestrator, _, _ := newTestOrchestrator(t)
 

--- a/internal/sdd/types.go
+++ b/internal/sdd/types.go
@@ -125,6 +125,9 @@ type PipelineStatus string
 
 const (
 	StatusIdle             PipelineStatus = "idle"
+	// StatusRunning means a phase artifact has been detected but the terminal has not yet gone
+	// quiet. The UI shows the active spinner; the decision gate has not opened yet.
+	StatusRunning          PipelineStatus = "running"
 	StatusAwaitingDecision PipelineStatus = "awaiting-decision"
 	StatusAdvancing        PipelineStatus = "advancing"
 	StatusRejected         PipelineStatus = "rejected"


### PR DESCRIPTION
## Summary

- **Bug 1 — No spinner while phase is running**: Artifact-detected phases (Specify, Clarify, Plan, Tasks) showed as `pending` with a static _"Run /speckit-… to continue"_ prompt even while the agent was actively writing output. A new `StatusRunning` pipeline state is set immediately when an artifact is first detected; `derivePhaseDisplayStatus` maps this to `PhaseDisplayActive`, showing the blue spinner in the pipeline bar.
- **Bug 2 — Gate card opened while agent still running**: `gateSddArtifact` called `HandlePhaseComplete` the instant the filesystem watcher fired, causing the Approve/Reject card to appear mid-run (observed: 6m 55s agent still processing, card already open). The completion call now fires only after PTY-quiet detection, consistent with how Validate and Implement have always worked.

## Changes

| File | What changed |
|---|---|
| `internal/sdd/types.go` | Added `StatusRunning PipelineStatus` constant |
| `internal/sdd/orchestrator.go` | Added `MarkPhaseRunning(phase) bool` — idempotent guard against duplicate watcher fires |
| `cmd/forge/sdd_wiring.go` | `derivePhaseDisplayStatus` new `StatusRunning → PhaseDisplayActive` branch; `gateSddArtifact` split into mark-running + goroutine; new `settleArtifactPhase` helper |
| `internal/sdd/orchestrator_test.go` | 4 tests: idle→running transition, idempotency, suppression when gate-open or complete |
| `cmd/forge/sdd_wiring_test.go` | 2 tests: `StatusRunning` in `derivePhaseDisplayStatus`; `buildPhaseStatuses` spinner integration |
| `CHANGELOG.md` | Both bugs documented under `[Unreleased]` |

## Test plan

- [ ] Run `/speckit-specify` in a fresh repo — pipeline bar shows Specify with blue spinner immediately
- [ ] Let the skill run to completion — gate card does not appear until terminal goes quiet (8s silence)
- [ ] Run `/speckit-plan` after approving Specify + Clarify — Plan shows spinner, not "Run /speckit-plan to continue"
- [ ] Verify duplicate watcher fires do not produce a double gate card (`PhaseRunCount` stays at 1 until settlement)
- [ ] `go test ./internal/sdd/... ./cmd/forge/...` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)