### PR TITLE
fix: SDD gate hook installs globally, works in all repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD hook install now targets global `~/.claude/` — works in all repos** — `install-sdd-hook.ps1` previously wrote to the project-level `.claude/settings.json` using a relative path, so the enforcement hook was silently inactive in every repo except `forge-terminal`. The script now copies `sdd-gate-check.ps1` to `~/.claude/scripts/` and registers the hook in `~/.claude/settings.json` with an absolute path, matching the behaviour of all other Forge global skills. The in-app hook-status check (`isSddHookInstalled`) was updated to search both the project-level and global settings files so the install-prompt banner correctly recognises a global install.
+
 ## [7.19.6] - 2026-06-20
 
 ---

--- a/cmd/forge/handlers_sdd.go
+++ b/cmd/forge/handlers_sdd.go
@@ -162,15 +162,41 @@ func handleSddHookStatus(w http.ResponseWriter, r *http.Request) {
 	writeSddJSON(w, http.StatusOK, map[string]any{"isInstalled": isSddHookInstalled()})
 }
 
-// isSddHookInstalled checks .claude/settings.json for the SDD gate enforcement hook command.
-// A substring match on the raw file bytes is intentional — it avoids a full JSON parse while
-// remaining robust to cosmetic whitespace differences.
+// isSddHookInstalled checks both the project-level .claude/settings.json and the global
+// ~/.claude/settings.json for the SDD gate enforcement hook command. Either location is
+// sufficient — the hook fires globally when installed in the user directory, which is the
+// recommended install path so it covers all repositories.
 func isSddHookInstalled() bool {
-	data, readErr := os.ReadFile(".claude/settings.json")
-	if readErr != nil {
-		return false
+	return isSddHookInstalledFromPaths(sddHookSettingsPaths())
+}
+
+// isSddHookInstalledFromPaths checks the supplied list of settings file paths for the
+// SDD gate enforcement hook. A substring match on raw bytes is intentional: it avoids a
+// full JSON parse while being robust to cosmetic whitespace differences in the file.
+// Separated from isSddHookInstalled so tests can inject controlled paths without touching
+// the real user home directory.
+func isSddHookInstalledFromPaths(settingsPaths []string) bool {
+	for _, settingsPath := range settingsPaths {
+		rawBytes, readErr := os.ReadFile(settingsPath)
+		if readErr != nil {
+			continue
+		}
+		if strings.Contains(string(rawBytes), sddHookScriptName) {
+			return true
+		}
 	}
-	return strings.Contains(string(data), sddHookScriptName)
+	return false
+}
+
+// sddHookSettingsPaths returns the ordered list of Claude Code settings files to check
+// for the SDD gate enforcement hook. Project-level is checked first; global user-level
+// is the canonical install location when the hook should cover all repositories.
+func sddHookSettingsPaths() []string {
+	paths := []string{filepath.Join(".claude", "settings.json")}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(homeDir, ".claude", "settings.json"))
+	}
+	return paths
 }
 
 // writeSddDecisionError maps orchestrator errors to precise HTTP status codes.

--- a/cmd/forge/handlers_sdd_test.go
+++ b/cmd/forge/handlers_sdd_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -292,19 +294,54 @@ func TestHandleSddHookStatus_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleSddHookStatus_AbsentSettingsFile_ReturnsNotInstalled(t *testing.T) {
-	// When .claude/settings.json does not exist, the hook is not installed.
-	// isSddHookInstalled reads relative to CWD; the test runs in cmd/forge/ which
-	// never has .claude/settings.json, so no fixture needed.
-	recorder := getHookStatus(t)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", recorder.Code)
+	// When neither settings file exists (empty path list), the hook is not installed.
+	isInstalled := isSddHookInstalledFromPaths([]string{})
+	if isInstalled {
+		t.Error("isInstalled = true with no settings files, want false")
 	}
-	var body map[string]any
-	if err := json.NewDecoder(recorder.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
+}
+
+func TestIsSddHookInstalledFromPaths_ProjectSettings_Found(t *testing.T) {
+	// A project-level settings file containing the hook script name returns true.
+	settingsDir := t.TempDir()
+	settingsFile := filepath.Join(settingsDir, "settings.json")
+	content := `{"hooks":{"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"powershell -File sdd-gate-check.ps1"}]}]}}`
+	if err := os.WriteFile(settingsFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
 	}
-	// isInstalled must be a boolean, not nil / missing.
-	if _, hasBool := body["isInstalled"].(bool); !hasBool {
-		t.Errorf("body[isInstalled] type = %T, want bool; body = %v", body["isInstalled"], body)
+	if !isSddHookInstalledFromPaths([]string{settingsFile}) {
+		t.Error("isInstalled = false with hook present in project settings, want true")
+	}
+}
+
+func TestIsSddHookInstalledFromPaths_GlobalSettings_Found(t *testing.T) {
+	// A global settings file containing the hook script name returns true even when
+	// the project settings file does not contain it.
+	globalDir := t.TempDir()
+	globalFile := filepath.Join(globalDir, "settings.json")
+	content := `{"hooks":{"PreToolUse":[{"matcher":"Skill","hooks":[{"type":"command","command":"C:\\Users\\user\\.claude\\scripts\\sdd-gate-check.ps1"}]}]}}`
+	if err := os.WriteFile(globalFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	missingProjectFile := filepath.Join(globalDir, "nonexistent.json")
+	if !isSddHookInstalledFromPaths([]string{missingProjectFile, globalFile}) {
+		t.Error("isInstalled = false with hook present in global settings, want true")
+	}
+}
+
+func TestIsSddHookInstalledFromPaths_NeitherFile_ReturnsFalse(t *testing.T) {
+	// When both settings files lack the hook script name, isInstalled is false.
+	settingsDir := t.TempDir()
+	projectFile := filepath.Join(settingsDir, "project-settings.json")
+	globalFile := filepath.Join(settingsDir, "global-settings.json")
+	emptyContent := `{"permissions":{}}`
+	if err := os.WriteFile(projectFile, []byte(emptyContent), 0o644); err != nil {
+		t.Fatalf("write project fixture: %v", err)
+	}
+	if err := os.WriteFile(globalFile, []byte(emptyContent), 0o644); err != nil {
+		t.Fatalf("write global fixture: %v", err)
+	}
+	if isSddHookInstalledFromPaths([]string{projectFile, globalFile}) {
+		t.Error("isInstalled = true with hook absent from both settings files, want false")
 	}
 }

--- a/scripts/install-sdd-hook.ps1
+++ b/scripts/install-sdd-hook.ps1
@@ -1,23 +1,39 @@
 # install-sdd-hook.ps1 — Installs the SDD gate enforcement PreToolUse hook into the
-# project-level Claude Code settings (.claude/settings.json). Run this once after
-# cloning, or after any time .claude/settings.json is reset.
+# GLOBAL Claude Code settings (~/.claude/settings.json) and copies the gate-check script
+# to ~/.claude/scripts/ so the hook fires in every repository, not just forge-terminal.
+# Run this once per machine after initial setup, or after a settings reset.
 # specs/008-sdd-real-enforcement FR-001.
 
 param([switch]$Force)
 
-$settingsPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..' '.claude' 'settings.json'))
-$hookCommand  = 'powershell -NoProfile -NonInteractive -File scripts/sdd-gate-check.ps1'
+$claudeUserDir   = Join-Path $env:USERPROFILE '.claude'
+$globalScriptsDir = Join-Path $claudeUserDir 'scripts'
+$globalSettings  = Join-Path $claudeUserDir 'settings.json'
+$sourceScript    = Join-Path $PSScriptRoot 'sdd-gate-check.ps1'
+$destScript      = Join-Path $globalScriptsDir 'sdd-gate-check.ps1'
 
-# Load existing settings or start with an empty object.
+# The hook command uses an absolute path so it resolves regardless of the CWD
+# in which the hook fires (i.e. any repository the developer works in).
+$hookCommand = "powershell -NoProfile -NonInteractive -File `"$destScript`""
+
+# --- Step 1: copy the gate-check script to the global scripts directory -----------
+
+$null = New-Item -ItemType Directory -Path $globalScriptsDir -Force
+Copy-Item -Path $sourceScript -Destination $destScript -Force
+Write-Host "Gate-check script copied to: $destScript" -ForegroundColor Cyan
+
+# --- Step 2: load or initialise the global settings file -------------------------
+
 $raw = '{}'
-if (Test-Path $settingsPath) {
-    $raw = Get-Content $settingsPath -Raw -Encoding UTF8
+if (Test-Path $globalSettings) {
+    $raw = Get-Content $globalSettings -Raw -Encoding UTF8
 }
 
-# Use PowerShell 5-compatible JSON parsing (no -AsHashtable flag needed).
+# PS 5.1-compatible JSON parsing — no -AsHashtable flag available.
 $settings = $raw | ConvertFrom-Json
 
-# Ensure hooks.PreToolUse exists as an array.
+# --- Step 3: ensure the PreToolUse hook array exists -----------------------------
+
 if (-not (Get-Member -InputObject $settings -Name 'hooks' -MemberType NoteProperty)) {
     $settings | Add-Member -MemberType NoteProperty -Name 'hooks' -Value (New-Object PSObject)
 }
@@ -25,27 +41,26 @@ if (-not (Get-Member -InputObject $settings.hooks -Name 'PreToolUse' -MemberType
     $settings.hooks | Add-Member -MemberType NoteProperty -Name 'PreToolUse' -Value @()
 }
 
-# Check whether our hook command is already present.
-$alreadyInstalled = $settings.hooks.PreToolUse | Where-Object {
+# --- Step 4: skip if already installed (unless -Force was passed) ----------------
+
+$isAlreadyInstalled = $settings.hooks.PreToolUse | Where-Object {
     $_.matcher -eq 'Skill' -and ($_.hooks | Where-Object { $_.command -eq $hookCommand })
 }
 
-if ($alreadyInstalled -and -not $Force) {
-    Write-Host 'SDD gate enforcement hook is already installed.' -ForegroundColor Green
+if ($isAlreadyInstalled -and -not $Force) {
+    Write-Host 'SDD gate enforcement hook is already installed in global settings.' -ForegroundColor Green
     exit 0
 }
 
-# Build and append the new hook entry.
+# --- Step 5: append the hook entry and write back --------------------------------
+
 $newEntry = [PSCustomObject]@{
     matcher = 'Skill'
     hooks   = @([PSCustomObject]@{ type = 'command'; command = $hookCommand })
 }
 $settings.hooks.PreToolUse = @($settings.hooks.PreToolUse) + $newEntry
 
-# Write back — ensure the parent directory exists.
-$null = New-Item -ItemType Directory -Path (Split-Path $settingsPath) -Force
-$settings | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -Encoding UTF8
+$settings | ConvertTo-Json -Depth 10 | Set-Content $globalSettings -Encoding UTF8
 
-$msg = 'SDD gate enforcement hook installed at ' + $settingsPath
-Write-Host $msg -ForegroundColor Green
+Write-Host "SDD gate enforcement hook installed in: $globalSettings" -ForegroundColor Green
 Write-Host 'Restart Claude Code for the hook to take effect.' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

- `install-sdd-hook.ps1` previously wrote to the project-level `.claude/settings.json` using a relative `scripts/` path — the hook silently fired only when Claude Code was in the `forge-terminal` directory, and not at all in any other repo (e.g. `AzureWorkflowPOC`)
- Script now copies `sdd-gate-check.ps1` to `~/.claude/scripts/` and registers the hook in `~/.claude/settings.json` with an absolute path, matching how all other Forge global skills are installed
- `isSddHookInstalled()` updated to check both project-level and global `~/.claude/settings.json`; extracted `isSddHookInstalledFromPaths()` for hermetic tests

## Test plan

- [x] `go test ./...` — all packages green
- [x] 3 new hermetic unit tests: project-settings found, global-settings found, neither-file returns false
- [ ] Restart Claude Code — "Gate enforcement inactive" banner and footer message should be gone
- [ ] Open a Claude Code session in `AzureWorkflowPOC` — hook fires (speckit skills blocked by open gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)