### PR TITLE
fix: gate card demand-pull when awaiting-decision phase is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD gate card now appears when you click an awaiting-decision phase** — Clicking a phase cell in `awaiting-decision` state demand-pulls the pending gate card from `/api/sdd/status` and opens the Approve/Reject/Clarify bar immediately, without waiting for a new WebSocket event. Previously, if the `SDD_PHASE_GATE` event was missed (e.g. after a reconnect or update), the gate card was gone with no way to recover it by clicking. `awaiting-decision` phase cells are now also styled as interactive buttons so the affordance is visible.
+
 ## [7.19.7] - 2026-06-20
 
 ---

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2213,6 +2213,7 @@ function App() {
           onAction={(action, clarifyText) => sddGate.submitDecision(action, clarifyText)}
           onDismiss={sddGate.dismiss}
           onFileOpen={handleFileOpen}
+          onAwaitingPhaseClick={sddGate.fetchPendingGate}
         />
       </div>
       {showEditor && editorFile && (

--- a/frontend/src/components/SddDashboard.jsx
+++ b/frontend/src/components/SddDashboard.jsx
@@ -82,7 +82,12 @@ function PhaseCell({ entry, isSelected, onClick }) {
   const statusMod = knownStatuses.includes(displayStatus) ? displayStatus : 'unknown'
   const icon = STATUS_ICON[displayStatus] ?? '?'
   const label = STATUS_LABEL[displayStatus] ?? displayStatus
-  const isClickable = displayStatus === 'complete'
+  // awaiting-decision phases are clickable so the developer can demand-pull the
+  // gate card when the WebSocket event was missed (e.g. after reconnection).
+  const isClickable = displayStatus === 'complete' || displayStatus === 'awaiting-decision'
+  const ariaLabel = displayStatus === 'awaiting-decision'
+    ? `${phase} phase — awaiting decision, click to open gate card`
+    : `${phase} phase — ${label}, click to view summary`
 
   return (
     <div
@@ -97,7 +102,7 @@ function PhaseCell({ entry, isSelected, onClick }) {
       tabIndex={isClickable ? 0 : undefined}
       onKeyDown={isClickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') onClick() } : undefined}
       aria-expanded={isClickable ? isSelected : undefined}
-      aria-label={isClickable ? `${phase} phase — ${label}, click to view summary` : undefined}
+      aria-label={isClickable ? ariaLabel : undefined}
     >
       <span className="sdd-dashboard__cell-icon">{icon}</span>
       <span className="sdd-dashboard__cell-name">{phase}</span>
@@ -383,6 +388,10 @@ export default function SddDashboard({
   onAction,
   onDismiss,
   onFileOpen,
+  // Called when the developer clicks a phase in awaiting-decision state.
+  // The parent wires this to useSddGate.fetchPendingGate so the gate card
+  // is demand-pulled from the server without waiting for a new WS event.
+  onAwaitingPhaseClick,
 }) {
   const [selectedPhase, setSelectedPhase] = useState(null)
   const [isClarifyOpen, setIsClarifyOpen] = useState(false)
@@ -390,8 +399,15 @@ export default function SddDashboard({
   const [isHookBannerDismissed, setIsHookBannerDismissed] = useState(false)
 
   const handleCellClick = useCallback((phaseName) => {
+    const phaseEntry = phases.find((p) => p.phase === phaseName)
+    if (phaseEntry?.displayStatus === 'awaiting-decision') {
+      // Demand-pull: fetch the pending gate card from the server rather than
+      // toggling the detail strip, which has no content for a pending gate.
+      onAwaitingPhaseClick?.()
+      return
+    }
     setSelectedPhase((prev) => (prev === phaseName ? null : phaseName))
-  }, [])
+  }, [phases, onAwaitingPhaseClick])
 
   const handleClarifyConfirm = useCallback((steer) => {
     setIsClarifyOpen(false)

--- a/frontend/src/components/SddDashboard.test.jsx
+++ b/frontend/src/components/SddDashboard.test.jsx
@@ -39,6 +39,7 @@ function DashboardFixture(props) {
       onAction={props.onAction ?? vi.fn()}
       onDismiss={props.onDismiss ?? vi.fn()}
       onFileOpen={props.onFileOpen ?? vi.fn()}
+      onAwaitingPhaseClick={props.onAwaitingPhaseClick ?? vi.fn()}
     />
   )
 }
@@ -135,6 +136,46 @@ describe('SddDashboard', () => {
     render(<DashboardFixture phases={phases} />)
     // The pending cell should have no button role.
     expect(screen.queryByRole('button', { name: /validate/ })).not.toBeInTheDocument()
+  })
+
+  it('awaiting-decision cell is interactive (has role=button)', () => {
+    // A phase with a pending gate must be clickable so the developer can demand-pull
+    // the gate card when the WebSocket event was missed (e.g. after reconnection).
+    const phases = [makePhase({ phase: 'plan', displayStatus: 'awaiting-decision' })]
+    render(<DashboardFixture phases={phases} />)
+    expect(screen.getByRole('button', { name: /plan/ })).toBeInTheDocument()
+  })
+
+  it('clicking an awaiting-decision cell calls onAwaitingPhaseClick', () => {
+    const onAwaitingPhaseClick = vi.fn()
+    render(
+      <DashboardFixture
+        phases={SIX_PHASES}
+        onAwaitingPhaseClick={onAwaitingPhaseClick}
+      />
+    )
+    // plan is the awaiting-decision phase in SIX_PHASES.
+    const planCell = screen.getByRole('button', { name: /plan/ })
+    fireEvent.click(planCell)
+
+    expect(onAwaitingPhaseClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking an awaiting-decision cell does not open the detail strip', () => {
+    // The detail strip shows artifacts for completed phases. Clicking an awaiting
+    // phase should trigger the gate-card demand pull, not open an artifact strip.
+    const onAwaitingPhaseClick = vi.fn()
+    render(
+      <DashboardFixture
+        phases={SIX_PHASES}
+        summaries={{ plan: { headline: 'Plan ready', producedItems: [], flags: [] } }}
+        onAwaitingPhaseClick={onAwaitingPhaseClick}
+      />
+    )
+    const planCell = screen.getByRole('button', { name: /plan/ })
+    fireEvent.click(planCell)
+
+    expect(screen.queryByText('Plan ready')).not.toBeInTheDocument()
   })
 
   // ── Detail strip ─────────────────────────────────────────────────────────

--- a/frontend/src/hooks/useSddGate.js
+++ b/frontend/src/hooks/useSddGate.js
@@ -123,6 +123,29 @@ export function useSddGate({ activeSessionId }) {
     [activeSessionId]
   )
 
+  // fetchPendingGate is the demand-pull path: when the developer clicks an
+  // awaiting-decision phase cell, the dashboard calls this to recover the gate
+  // card without waiting for a new WebSocket event. This covers the case where
+  // the SDD_PHASE_GATE event was missed (e.g. the connection dropped mid-session
+  // during an update and the card never re-arrived on reconnect).
+  const fetchPendingGate = useCallback(async () => {
+    if (!activeSessionId) return
+    try {
+      const response = await fetch(
+        `${STATUS_ENDPOINT}?sessionId=${encodeURIComponent(activeSessionId)}`,
+        { credentials: 'same-origin' }
+      )
+      if (!response.ok) return
+      const data = await response.json()
+      if (data?.pendingCard) {
+        setCard({ type: 'SDD_PHASE_GATE', ...data.pendingCard })
+      }
+    } catch {
+      // Best-effort: if the backend is unreachable the user will see nothing
+      // change. The next WS reconnect will deliver the card again.
+    }
+  }, [activeSessionId])
+
   // dismiss is the failsafe exit: it clears the card locally with no backend
   // call, so the user can always escape even when the backend is unreachable.
   const dismiss = useCallback(() => {
@@ -179,6 +202,7 @@ export function useSddGate({ activeSessionId }) {
     phaseSummaries,
     isHookInstalled,
     handleWsMessage,
+    fetchPendingGate,
     submitDecision,
     dismiss,
   }

--- a/frontend/src/hooks/useSddGate.test.js
+++ b/frontend/src/hooks/useSddGate.test.js
@@ -426,3 +426,78 @@ describe('useSddGate — phaseSummaries (spec-006)', () => {
     expect(result.current.phaseSummaries.current['plan']).toBeUndefined()
   })
 })
+
+// ── fetchPendingGate — demand-pull path (fix: sdd-gate-card-demand-pull) ──────
+// When the developer clicks an awaiting-decision phase cell, the dashboard calls
+// fetchPendingGate() to recover the gate card without waiting for a new WebSocket event.
+
+describe('useSddGate — fetchPendingGate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes fetchPendingGate as a function', () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+    expect(typeof result.current.fetchPendingGate).toBe('function')
+  })
+
+  it('sets the card when the status endpoint returns a pendingCard', async () => {
+    const pendingCard = {
+      cardId:    'gate-plan-77',
+      sessionId: ACTIVE_SESSION_ID,
+      phase:     'plan',
+      actions:   ['approve', 'reject', 'clarify'],
+    }
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: false })         // hook-status (mount)
+      .mockResolvedValueOnce({ ok: false })         // status recovery (mount)
+      .mockResolvedValueOnce({                      // fetchPendingGate call
+        ok: true,
+        json: () => Promise.resolve({ pendingCard }),
+      })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    await act(async () => {
+      await result.current.fetchPendingGate()
+    })
+
+    expect(result.current.isCardOpen).toBe(true)
+    expect(result.current.card).toMatchObject({ phase: 'plan', cardId: 'gate-plan-77' })
+  })
+
+  it('leaves card null when the status endpoint returns no pendingCard', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: false })         // hook-status (mount)
+      .mockResolvedValueOnce({ ok: false })         // status recovery (mount)
+      .mockResolvedValueOnce({                      // fetchPendingGate call
+        ok: true,
+        json: () => Promise.resolve({ phases: [], feature: '' }),
+      })
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    await act(async () => {
+      await result.current.fetchPendingGate()
+    })
+
+    expect(result.current.isCardOpen).toBe(false)
+  })
+
+  it('silently does nothing when the fetch throws', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: false })         // hook-status (mount)
+      .mockResolvedValueOnce({ ok: false })         // status recovery (mount)
+      .mockRejectedValueOnce(new Error('network error')) // fetchPendingGate call
+
+    const { result } = renderHook(() => useSddGate({ activeSessionId: ACTIVE_SESSION_ID }))
+
+    // Should not throw.
+    await act(async () => {
+      await result.current.fetchPendingGate()
+    })
+
+    expect(result.current.isCardOpen).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Clicking an `awaiting-decision` phase cell now immediately fetches the pending gate card from `/api/sdd/status` and opens the Approve/Reject/Clarify bar — no waiting for a new WebSocket event
- If the `SDD_PHASE_GATE` event was missed (reconnect, app update, tab switch), the developer was previously stuck with an open gate and no UI to act on it
- `awaiting-decision` cells are now styled as interactive buttons so the affordance is visible

## What changed

| File | Change |
|------|--------|
| `useSddGate.js` | New `fetchPendingGate()` async callback — calls `/api/sdd/status`, sets card from `pendingCard` |
| `SddDashboard.jsx` | `awaiting-decision` phases now render as clickable buttons; click routes to `onAwaitingPhaseClick` not detail strip |
| `App.jsx` | Wire `onAwaitingPhaseClick={sddGate.fetchPendingGate}` |

## Test plan

- [x] `go test ./...` — all Go packages green
- [x] `npx vitest run` — 377 frontend tests green
- [x] 7 new unit tests: `fetchPendingGate` existence, sets card, no-op when no pendingCard, silent on fetch error; awaiting-decision cell is a button, calls onAwaitingPhaseClick on click, does not open detail strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)