### PR TITLE
fix: SDD bar phases never advance (watcher settlement goroutine blocked by started signal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SDD bar phases now advance correctly** — The phase bar was stuck at "pending" for all phases in v7.20.0. Root cause: the PreToolUse hook's `started` signal marks the phase running, but the file watcher then sees `MarkPhaseRunning` return false and exits before launching the settlement goroutine that opens the gate. Added `IsPhaseRunning` to the orchestrator so the watcher can detect "already claimed by the hook" and still settle the phase, making the gate open as expected.
+- **SDD phase bar pending state is more visible** — Pending phase cells were rendered with `#4a4a4a` icon color on a `#0e0e0e` background (near-invisible), making a correctly-idle bar look identical to a broken one. Pending icons now use `#666` for clear visual distinction from active (#60a5fa) and complete (#22c55e) states.
+
 ## [7.20.0] - 2026-06-22
 
 ---

--- a/cmd/forge/sdd_wiring.go
+++ b/cmd/forge/sdd_wiring.go
@@ -289,17 +289,22 @@ func gateSddArtifact(pipeline *sddPipeline, sessionID, changedPath string) {
 	pipeline.orchestrator.SetFeatureDir(featureDir)
 
 	// Step 1 — mark running immediately so the UI spinner appears before the gate opens.
-	// Returns false when the gate is already open (duplicate watcher fire) or the pipeline is
-	// complete; skip in those cases to avoid corrupting orchestrator state.
-	if !pipeline.orchestrator.MarkPhaseRunning(phase) {
-		return
+	// Returns false when the gate is already open (a duplicate watcher fire), the pipeline is
+	// complete, OR this phase was already claimed by the authoritative `started` signal from the
+	// PreToolUse hook (specs/010). In the last case we still need the settlement goroutine — the
+	// hook marks running early but never sends `complete`, so the watcher is the sole gate-opener.
+	isNewTransition := pipeline.orchestrator.MarkPhaseRunning(phase)
+	isAlreadyRunningThisPhase := !isNewTransition && pipeline.orchestrator.IsPhaseRunning(phase)
+	if !isNewTransition && !isAlreadyRunningThisPhase {
+		return // Duplicate fire, gate open, or pipeline complete — nothing to do.
 	}
-	broadcastPhaseStatus(sessionID)
+	if isNewTransition {
+		broadcastPhaseStatus(sessionID) // First transition: push spinner to frontend.
+	}
 
 	// Step 2 — wait for PTY silence, then open the gate. This watcher path is now the FALLBACK
-	// (specs/010, FR-002): the authoritative phase-event is the primary completion signal. If it
-	// already opened this phase's gate while we were settling, the watcher stands down so the
-	// phase is never completed twice.
+	// (specs/010, FR-002): if the authoritative phase-event already opened the gate while we were
+	// settling, the watcher stands down so the phase is never completed twice.
 	go func() {
 		settleArtifactPhase(sessionID)
 		state := pipeline.orchestrator.State()

--- a/frontend/src/components/SddDashboard.css
+++ b/frontend/src/components/SddDashboard.css
@@ -128,7 +128,7 @@
   text-align: center;
 }
 
-.sdd-dashboard__cell--pending     .sdd-dashboard__cell-icon { color: #4a4a4a; }
+.sdd-dashboard__cell--pending     .sdd-dashboard__cell-icon { color: #666; }
 .sdd-dashboard__cell--active      .sdd-dashboard__cell-icon { color: #60a5fa; animation: sdd-spin 0.8s linear infinite; }
 .sdd-dashboard__cell--awaiting-decision .sdd-dashboard__cell-icon { color: #fbbf24; }
 .sdd-dashboard__cell--iterating   .sdd-dashboard__cell-icon { color: #f59e0b; animation: sdd-spin 0.8s linear infinite; }

--- a/internal/sdd/orchestrator.go
+++ b/internal/sdd/orchestrator.go
@@ -127,6 +127,16 @@ func (o *Orchestrator) MarkPhaseRunning(phase PhaseName) bool {
 	return true
 }
 
+// IsPhaseRunning reports whether the pipeline is currently in StatusRunning for the exact
+// given phase. The watcher fallback uses this to determine whether a `started` signal from
+// the PreToolUse hook already claimed the running slot — if so, the watcher must still launch
+// its settlement goroutine even though MarkPhaseRunning returned false (specs/010 interaction fix).
+func (o *Orchestrator) IsPhaseRunning(phase PhaseName) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.state.Status == StatusRunning && o.state.CurrentPhase == phase
+}
+
 // ReconcileFromDisk forward-scans the phase table and advances CurrentPhase to the highest
 // phase whose expected artifact exists on disk. It stops at the first missing artifact so that
 // only a contiguous prefix of completed phases is recognised. The method is idempotent and

--- a/internal/sdd/orchestrator_test.go
+++ b/internal/sdd/orchestrator_test.go
@@ -311,6 +311,41 @@ func TestMarkPhaseRunning_SuppressedWhenPipelineComplete(t *testing.T) {
 	}
 }
 
+func TestIsPhaseRunning_TrueWhenStatusRunningAndPhaseMatches(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if !orchestrator.IsPhaseRunning(PhaseSpecify) {
+		t.Error("IsPhaseRunning(specify) = false; want true while pipeline is StatusRunning for specify")
+	}
+}
+
+func TestIsPhaseRunning_FalseWhenDifferentPhaseIsRunning(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	orchestrator.MarkPhaseRunning(PhaseSpecify)
+
+	if orchestrator.IsPhaseRunning(PhaseClarify) {
+		t.Error("IsPhaseRunning(clarify) = true; want false when specify is the running phase")
+	}
+}
+
+func TestIsPhaseRunning_FalseWhenAwaitingDecision(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+	orchestrator.HandlePhaseComplete(PhaseSpecify, "spec.md")
+
+	if orchestrator.IsPhaseRunning(PhaseSpecify) {
+		t.Error("IsPhaseRunning(specify) = true; want false when gate is open (AwaitingDecision)")
+	}
+}
+
+func TestIsPhaseRunning_FalseWhenIdle(t *testing.T) {
+	orchestrator, _, _ := newTestOrchestrator(t)
+
+	if orchestrator.IsPhaseRunning(PhaseSpecify) {
+		t.Error("IsPhaseRunning(specify) = true; want false when pipeline is idle")
+	}
+}
+
 func TestSetFeatureDir_UpdatesStateForLazyActivation(t *testing.T) {
 	orchestrator, _, _ := newTestOrchestrator(t)
 


### PR DESCRIPTION
## Summary

- **Root cause**: In v7.20.0 the PreToolUse hook began emitting `started` phase signals, which call `MarkPhaseRunning` and set the pipeline to `StatusRunning`. When the file watcher later detects the phase artifact it calls `MarkPhaseRunning` again — which returns `false` (already running) — and exits early. The settlement goroutine that waits for PTY-quiet and opens the decision gate **never starts**, so all phases are permanently stuck at "active" or "pending" and the bar appears completely non-functional.
- **Fix**: Added `IsPhaseRunning(phase)` to the orchestrator so `gateSddArtifact` can distinguish "hook claimed the running slot" (→ still need to settle) from "gate already open / pipeline complete" (→ skip). The settlement goroutine now runs in both cases, while the `broadcastPhaseStatus` spinner push only fires on a genuinely new transition.
- **CSS**: Raised pending-phase icon color from `#4a4a4a` to `#666` — the near-black-on-black contrast made an idle bar visually indistinguishable from a broken one.

## Test plan

- [ ] `go test ./internal/sdd/...` — 4 new `TestIsPhaseRunning_*` tests cover all states
- [ ] `go test ./...` — full suite green
- [ ] Invoke `/speckit-specify` in a tab and confirm the Specify phase shows the blue spinner and then the gate card appears
- [ ] Confirm pending phases (not yet started) show as visible gray, not invisible

🤖 Generated with [Claude Code](https://claude.com/claude-code)