### PR TITLE
fix: suppress blank console windows on Windows for git subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **SDD bar phases now advance correctly** — The phase bar was stuck at "pending" for all phases in v7.20.0. Root cause: the PreToolUse hook's `started` signal marks the phase running, but the file watcher then sees `MarkPhaseRunning` return false and exits before launching the settlement goroutine that opens the gate. Added `IsPhaseRunning` to the orchestrator so the watcher can detect "already claimed by the hook" and still settle the phase, making the gate open as expected.
 - **SDD phase bar pending state is more visible** — Pending phase cells were rendered with `#4a4a4a` icon color on a `#0e0e0e` background (near-invisible), making a correctly-idle bar look identical to a broken one. Pending icons now use `#666` for clear visual distinction from active (#60a5fa) and complete (#22c55e) states.
+- **No more blank console windows on tab open or app restart (Windows)** — Every `git` subprocess spawned by the SDD worktree automation (`internal/git`) now sets `CREATE_NO_WINDOW` via `SysProcAttr`. Previously, each `git rev-parse` / `git worktree add` call during bind or the startup sweep briefly opened a visible blank console window on Windows, producing the cascading-window effect shown when a second concurrent tab was opened or when the app restarted after an update.
 
 ## [7.20.0] - 2026-06-22
 

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -26,6 +26,7 @@ type execRunner struct{}
 func (execRunner) Run(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	setSysProcAttr(cmd) // suppress console window on Windows (CREATE_NO_WINDOW)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/git/runner_unix.go
+++ b/internal/git/runner_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+// runner_unix.go — no-op platform shim so runner.go compiles on non-Windows.
+package git
+
+import "os/exec"
+
+// setSysProcAttr is a no-op on non-Windows: console suppression is not needed
+// because Unix does not create visible windows for subprocess spawns.
+func setSysProcAttr(_ *exec.Cmd) {}

--- a/internal/git/runner_unix_test.go
+++ b/internal/git/runner_unix_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+// runner_unix_test.go — verifies setSysProcAttr is a safe no-op on non-Windows.
+package git
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSetSysProcAttr_IsNoOpOnUnix(t *testing.T) {
+	cmd := exec.Command("git", "version")
+	before := cmd.SysProcAttr
+	setSysProcAttr(cmd)
+	if cmd.SysProcAttr != before {
+		t.Error("setSysProcAttr modified SysProcAttr on a non-Windows platform; expected no-op")
+	}
+}

--- a/internal/git/runner_windows.go
+++ b/internal/git/runner_windows.go
@@ -1,0 +1,20 @@
+// runner_windows.go — suppresses visible console windows for git subprocesses on Windows.
+// Without CREATE_NO_WINDOW every `git` call spawned by the SDD worktree automation
+// briefly shows a blank console window, producing the cascading-window effect visible
+// when a new tab opens or when the app restarts after an update.
+package git
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr hides the console window for a git subprocess on Windows.
+// Mirrors the hideWindow helper in cmd/forge/windows.go but lives in the git
+// package so the internal runner can call it without a package-level dependency.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: 0x08000000, // CREATE_NO_WINDOW
+	}
+}

--- a/internal/git/runner_windows_test.go
+++ b/internal/git/runner_windows_test.go
@@ -1,0 +1,23 @@
+// runner_windows_test.go — verifies setSysProcAttr applies CREATE_NO_WINDOW on Windows.
+package git
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSetSysProcAttr_SetsHideWindowAndCreationFlags(t *testing.T) {
+	cmd := exec.Command("git", "version")
+	setSysProcAttr(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("setSysProcAttr did not set SysProcAttr; want non-nil on Windows")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("SysProcAttr.HideWindow = false; want true")
+	}
+	const createNoWindow = uint32(0x08000000)
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Errorf("SysProcAttr.CreationFlags = %#x; want CREATE_NO_WINDOW (%#x) set", cmd.SysProcAttr.CreationFlags, createNoWindow)
+	}
+}


### PR DESCRIPTION
## Summary

- Every git command spawned in v7.20.0 (`git worktree add/list/remove`, `git rev-parse`, `git branch`, etc.) appeared as a blank console window on Windows. 5–6 commands fire per tab bind, so opening a new tab produced a cascade of visible windows.
- Root cause: `internal/git/runner.go` calls `exec.Command("git", …)` without `CREATE_NO_WINDOW`, so Windows always shows a console for the subprocess.
- Fix: platform shims (`runner_windows.go` / `runner_unix.go`) set `HideWindow: true` + `CreationFlags: 0x08000000` on Windows and are a no-op on Unix. The shim is called in `execRunner.Run` with a one-line addition.

## Test plan

- [ ] `go test ./internal/git/...` — `TestSetSysProcAttr_SetsHideWindowAndCreationFlags` (Windows) and `TestSetSysProcAttr_IsNoOpOnUnix` (Unix) both pass
- [ ] `go test ./...` — full suite green
- [ ] Open a new tab in Forge Terminal; confirm no blank console windows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)