### PR TITLE
fix: pre-commit test-file gate understands C#/Java/Python/Rust (no more forced --no-verify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scaffolded pre-commit "test file gate" no longer false-flags C#/Java/Python/Rust repos into `--no-verify`** — The generated pre-commit hook (`internal/workflow/templates.go`, both PowerShell and Bash variants) listed `.cs`, `.java`, `.py`, `.rs` as source extensions but only knew how to find a **Go** (`_test.go`) or **JS/TS** (`.test`/`.spec`) test file. For every other language it computed a JS-style expected name (e.g. `Foo.test.cs`), which never matches real conventions — so a C# repo using `FooTests.cs` had *every* new source file flagged "no corresponding test file," forcing developers and agents to commit with `git commit --no-verify`. Worse, the `FooTests.cs` test file itself was then flagged as untested source. Replaced the Go/JS-only logic with per-language candidates searched repo-wide (test projects/dirs are common): Go `_test.go`; JS/TS `.test`/`.spec`; Python `test_` prefix or `_test` suffix; Rust `_test.rs` **or** an inline `#[cfg(test)]` module; C# `Tests`/`Test` suffix; Java `Test`/`Tests`/`IT`. The "is this file itself a test?" exclusion was widened to match. Guarded by content tests over both hook variants and a behavioural test that **executes** the rendered Bash hook in a throwaway git repo, proving a lone `Calculator.cs` is flagged and adding `CalculatorTests.cs` satisfies the gate (Red→Green). NOTE: applies to newly scaffolded repos and any repo that re-runs `scripts/install-workflow-hooks.{ps1,sh}`; an already-installed buggy hook must be regenerated to pick up the fix.
+
 ## [7.23.2] - 2026-06-29
 
 ---

--- a/internal/workflow/templates.go
+++ b/internal/workflow/templates.go
@@ -637,7 +637,6 @@ var preCommitPS1Template = "#!/usr/bin/env pwsh\n" +
 	"if (-not $stagedFiles) { exit 0 }\n" +
 	"\n" +
 	"$sourceExtensions = @(\".go\", \".js\", \".jsx\", \".ts\", \".tsx\", \".py\", \".rs\", \".java\", \".cs\")\n" +
-	"$testPatterns = @(\"_test.go\", \".test.js\", \".test.jsx\", \".test.ts\", \".test.tsx\", \".spec.js\", \".spec.jsx\", \".spec.ts\", \".spec.tsx\", \"_test.py\", \"_test.rs\")\n" +
 	"$sourceFiles = $stagedFiles | Where-Object {\n" +
 	"    $extension = [System.IO.Path]::GetExtension($_)\n" +
 	"    $sourceExtensions -contains $extension\n" +
@@ -660,9 +659,11 @@ var preCommitPS1Template = "#!/usr/bin/env pwsh\n" +
 	"}\n" +
 	"\n" +
 	"# ── TEST FILE GATE (Gate 4) ─────────────────────────────────────────────\n" +
-	"# Every new source file must have a corresponding test file staged or on disk.\n" +
-	"# Build output directories are excluded — they contain compiled artifacts, not\n" +
-	"# authored source code, and must never be flagged for missing test coverage.\n" +
+	"# Every new source file must have a corresponding test file — staged or found\n" +
+	"# anywhere in the repo (test projects/dirs are common). Conventions are\n" +
+	"# language-specific: Go (_test.go), JS/TS (.test/.spec), Python (test_ prefix\n" +
+	"# or _test suffix), Rust (_test.rs or inline #[cfg(test)]), C# (Tests/Test\n" +
+	"# suffix), Java (Test/Tests/IT). Build output directories are excluded.\n" +
 	"$buildOutputDirs = @(\"cmd/forge/web/\", \"frontend/dist/\", \"bin/\")\n" +
 	"$newSourceFiles = git diff --cached --name-only --diff-filter=A 2>$null | Where-Object {\n" +
 	"    $extension = [System.IO.Path]::GetExtension($_)\n" +
@@ -672,25 +673,43 @@ var preCommitPS1Template = "#!/usr/bin/env pwsh\n" +
 	"    }\n" +
 	"    return $true\n" +
 	"}\n" +
-	"# Exclude files that are themselves test files\n" +
+	"# Recognise a path that is itself a test file (so a new test file isn't flagged).\n" +
 	"$isTestFile = { param($f)\n" +
-	"    foreach ($pattern in $testPatterns) { if ($f -like \"*$pattern\") { return $true } }\n" +
+	"    $name = [System.IO.Path]::GetFileName($f)\n" +
+	"    if ($name -match '(_test\\.go|\\.test\\.(js|jsx|ts|tsx)|\\.spec\\.(js|jsx|ts|tsx)|_test\\.py|_test\\.rs)$') { return $true }\n" +
+	"    if ($name -like 'test_*.py') { return $true }\n" +
+	"    if ($name -match '(Tests|Test)\\.cs$') { return $true }\n" +
+	"    if ($name -match '(Test|Tests|IT)\\.java$') { return $true }\n" +
 	"    return $false\n" +
+	"}\n" +
+	"# Candidate test FILE NAMES for a source leaf, by language.\n" +
+	"$testCandidates = { param($leaf, $ext)\n" +
+	"    switch ($ext) {\n" +
+	"        '.go'   { return @(\"${leaf}_test.go\") }\n" +
+	"        '.js'   { return @(\"${leaf}.test.js\", \"${leaf}.spec.js\") }\n" +
+	"        '.jsx'  { return @(\"${leaf}.test.jsx\", \"${leaf}.spec.jsx\") }\n" +
+	"        '.ts'   { return @(\"${leaf}.test.ts\", \"${leaf}.spec.ts\") }\n" +
+	"        '.tsx'  { return @(\"${leaf}.test.tsx\", \"${leaf}.spec.tsx\") }\n" +
+	"        '.py'   { return @(\"test_${leaf}.py\", \"${leaf}_test.py\") }\n" +
+	"        '.rs'   { return @(\"${leaf}_test.rs\") }\n" +
+	"        '.cs'   { return @(\"${leaf}Tests.cs\", \"${leaf}Test.cs\", \"${leaf}.Tests.cs\", \"${leaf}.Test.cs\") }\n" +
+	"        '.java' { return @(\"${leaf}Test.java\", \"${leaf}Tests.java\", \"${leaf}IT.java\") }\n" +
+	"        default { return @() }\n" +
+	"    }\n" +
 	"}\n" +
 	"foreach ($newFile in $newSourceFiles) {\n" +
 	"    if (& $isTestFile $newFile) { continue }\n" +
-	"    # Determine expected test file path based on language\n" +
 	"    $extension = [System.IO.Path]::GetExtension($newFile)\n" +
-	"    $baseName = $newFile.Substring(0, $newFile.Length - $extension.Length)\n" +
+	"    $leaf = [System.IO.Path]::GetFileNameWithoutExtension($newFile)\n" +
 	"    $hasTest = $false\n" +
-	"    if ($extension -eq \".go\") {\n" +
-	"        $expectedTest = \"${baseName}_test.go\"\n" +
-	"        if (($stagedFiles -contains $expectedTest) -or (Test-Path $expectedTest)) { $hasTest = $true }\n" +
-	"    } else {\n" +
-	"        # JS/TS: check for .test and .spec variants\n" +
-	"        foreach ($testSuffix in @(\".test$extension\", \".spec$extension\")) {\n" +
-	"            $expectedTest = \"${baseName}${testSuffix}\"\n" +
-	"            if (($stagedFiles -contains $expectedTest) -or (Test-Path $expectedTest)) { $hasTest = $true; break }\n" +
+	"    # Rust commonly keeps unit tests inline in the same file via #[cfg(test)].\n" +
+	"    if ($extension -eq '.rs' -and (Test-Path $newFile) -and (Select-String -Path $newFile -Pattern '#\\[cfg\\(test\\)\\]' -Quiet -ErrorAction SilentlyContinue)) {\n" +
+	"        $hasTest = $true\n" +
+	"    }\n" +
+	"    if (-not $hasTest) {\n" +
+	"        foreach ($cand in (& $testCandidates $leaf $extension)) {\n" +
+	"            if ($stagedFiles | Where-Object { [System.IO.Path]::GetFileName($_) -eq $cand }) { $hasTest = $true; break }\n" +
+	"            if (Get-ChildItem -Path . -Recurse -File -Filter $cand -ErrorAction SilentlyContinue | Select-Object -First 1) { $hasTest = $true; break }\n" +
 	"        }\n" +
 	"    }\n" +
 	"    if (-not $hasTest) {\n" +
@@ -776,26 +795,33 @@ var preCommitSHTemplate = "#!/usr/bin/env bash\n" +
 	"new_source_files=$(git diff --cached --name-only --diff-filter=A 2>/dev/null | grep -E '\\.(go|js|jsx|ts|tsx|py|rs|java|cs)$' | grep -vE '^(cmd/forge/web/|frontend/dist/|bin/)')\n" +
 	"if [[ -n \"$new_source_files\" ]]; then\n" +
 	"    while IFS= read -r new_file; do\n" +
-	"        # Skip files that are themselves test files\n" +
-	"        if echo \"$new_file\" | grep -qE '(_test\\.go|\\.test\\.(js|jsx|ts|tsx)|\\.spec\\.(js|jsx|ts|tsx)|_test\\.py|_test\\.rs)$'; then\n" +
-	"            continue\n" +
-	"        fi\n" +
+	"        [[ -z \"$new_file\" ]] && continue\n" +
+	"        base=$(basename \"$new_file\")\n" +
+	"        # Skip files that are themselves test files (every supported convention).\n" +
+	"        if echo \"$base\" | grep -qE '(_test\\.go|\\.test\\.(js|jsx|ts|tsx)|\\.spec\\.(js|jsx|ts|tsx)|_test\\.py|_test\\.rs|Tests?\\.cs|(Test|Tests|IT)\\.java)$'; then continue; fi\n" +
+	"        if echo \"$base\" | grep -qE '^test_.*\\.py$'; then continue; fi\n" +
 	"        extension=\"${new_file##*.}\"\n" +
-	"        base_name=\"${new_file%.*}\"\n" +
+	"        leaf=\"${base%.*}\"\n" +
 	"        has_test=false\n" +
-	"        if [[ \"$extension\" == \"go\" ]]; then\n" +
-	"            expected_test=\"${base_name}_test.go\"\n" +
-	"            if echo \"$staged_files\" | grep -qF \"$expected_test\" || [[ -f \"$expected_test\" ]]; then\n" +
-	"                has_test=true\n" +
-	"            fi\n" +
-	"        else\n" +
-	"            # JS/TS: check for .test and .spec variants\n" +
-	"            for test_suffix in \".test.${extension}\" \".spec.${extension}\"; do\n" +
-	"                expected_test=\"${base_name}${test_suffix}\"\n" +
-	"                if echo \"$staged_files\" | grep -qF \"$expected_test\" || [[ -f \"$expected_test\" ]]; then\n" +
-	"                    has_test=true\n" +
-	"                    break\n" +
-	"                fi\n" +
+	"        # Candidate test FILE NAMES for this source leaf, by language.\n" +
+	"        candidates=\"\"\n" +
+	"        case \"$extension\" in\n" +
+	"            go)   candidates=\"${leaf}_test.go\" ;;\n" +
+	"            js)   candidates=\"${leaf}.test.js ${leaf}.spec.js\" ;;\n" +
+	"            jsx)  candidates=\"${leaf}.test.jsx ${leaf}.spec.jsx\" ;;\n" +
+	"            ts)   candidates=\"${leaf}.test.ts ${leaf}.spec.ts\" ;;\n" +
+	"            tsx)  candidates=\"${leaf}.test.tsx ${leaf}.spec.tsx\" ;;\n" +
+	"            py)   candidates=\"test_${leaf}.py ${leaf}_test.py\" ;;\n" +
+	"            rs)   candidates=\"${leaf}_test.rs\" ;;\n" +
+	"            cs)   candidates=\"${leaf}Tests.cs ${leaf}Test.cs ${leaf}.Tests.cs ${leaf}.Test.cs\" ;;\n" +
+	"            java) candidates=\"${leaf}Test.java ${leaf}Tests.java ${leaf}IT.java\" ;;\n" +
+	"        esac\n" +
+	"        # Rust frequently keeps unit tests inline via #[cfg(test)].\n" +
+	"        if [[ \"$extension\" == \"rs\" && -f \"$new_file\" ]] && grep -q '#\\[cfg(test)\\]' \"$new_file\"; then has_test=true; fi\n" +
+	"        if [[ \"$has_test\" == \"false\" ]]; then\n" +
+	"            for cand in $candidates; do\n" +
+	"                # A test file staged or already present anywhere in the repo satisfies the gate.\n" +
+	"                if [[ -n \"$(find . -type f -name \"$cand\" 2>/dev/null | head -n1)\" ]]; then has_test=true; break; fi\n" +
 	"            done\n" +
 	"        fi\n" +
 	"        if [[ \"$has_test\" == \"false\" ]]; then\n" +

--- a/internal/workflow/templates_testgate_test.go
+++ b/internal/workflow/templates_testgate_test.go
@@ -1,0 +1,124 @@
+// templates_testgate_test.go — guards the scaffolded pre-commit "test file gate"
+// against the documented bug where only Go and JS/TS test conventions were
+// understood. A C#, Java, Python, or Rust source file could NEVER satisfy the
+// gate (it computed a JS-style "Foo.test.cs" expected name), so every commit in
+// those repos was false-flagged and forced `git commit --no-verify`.
+package workflow
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// preCommitRenderers runs each assertion against both rendered hook variants.
+var preCommitRenderers = map[string]func(WorkflowConfig) (string, error){
+	"pre-commit.ps1": RenderPreCommitPS1,
+	"pre-commit.sh":  RenderPreCommitSH,
+}
+
+// TestPreCommitGate_RecognizesNonJSTestConventions asserts the rendered hooks
+// know the test-file naming conventions of every language they treat as source,
+// not just Go and JS/TS.
+func TestPreCommitGate_RecognizesNonJSTestConventions(t *testing.T) {
+	for name, render := range preCommitRenderers {
+		script, err := render(DefaultConfig())
+		if err != nil {
+			t.Fatalf("%s: render failed: %v", name, err)
+		}
+		// C# tests are <Name>Tests.cs / <Name>Test.cs — never <Name>.test.cs.
+		if !strings.Contains(script, "Tests.cs") {
+			t.Errorf("%s: gate does not recognize the C# *Tests.cs convention", name)
+		}
+		// Python's dominant convention is the test_ prefix.
+		if !strings.Contains(script, "test_") {
+			t.Errorf("%s: gate does not recognize the Python test_ prefix convention", name)
+		}
+		// Java tests are <Name>Test.java.
+		if !strings.Contains(script, "Test.java") {
+			t.Errorf("%s: gate does not recognize the Java *Test.java convention", name)
+		}
+		// Rust unit tests are frequently inline via #[cfg(test)].
+		if !strings.Contains(script, "cfg(test)") {
+			t.Errorf("%s: gate does not honor Rust inline #[cfg(test)] tests", name)
+		}
+	}
+}
+
+// TestPreCommitGate_BashBehaviour_CSharp executes the real rendered Bash hook in
+// a throwaway git repo and proves the behaviour end-to-end: a lone C# source
+// file is flagged, and adding the conventional <Name>Tests.cs satisfies the gate.
+func TestPreCommitGate_BashBehaviour_CSharp(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available — skipping behavioural hook test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available — skipping behavioural hook test")
+	}
+
+	script, err := RenderPreCommitSH(DefaultConfig())
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	hookPath := filepath.Join(dir, "pre-commit")
+	if err := os.WriteFile(hookPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	gitInit(t, dir)
+
+	// Case A — a lone C# source file must be flagged for a missing test.
+	writeFile(t, dir, "Calculator.cs", "namespace App; public class Calculator {}")
+	gitRun(t, dir, "add", "Calculator.cs")
+	out := runHook(t, bash, hookPath, dir)
+	if !strings.Contains(out, "TEST FILE") || !strings.Contains(out, "Calculator.cs") {
+		t.Fatalf("expected a TEST FILE violation for a lone Calculator.cs, got:\n%s", out)
+	}
+
+	// Case B — adding the conventional CalculatorTests.cs must satisfy the gate.
+	writeFile(t, dir, "CalculatorTests.cs", "namespace App.Tests; public class CalculatorTests {}")
+	gitRun(t, dir, "add", "CalculatorTests.cs")
+	out = runHook(t, bash, hookPath, dir)
+	if strings.Contains(out, "TEST FILE: New source file 'Calculator.cs'") {
+		t.Fatalf("CalculatorTests.cs should satisfy the gate for Calculator.cs, got:\n%s", out)
+	}
+}
+
+// ── test helpers ─────────────────────────────────────────────────────────────
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	gitRun(t, dir, "init", "-q")
+	gitRun(t, dir, "config", "user.email", "test@example.com")
+	gitRun(t, dir, "config", "user.name", "test")
+	gitRun(t, dir, "checkout", "-q", "-b", "feature/test-gate")
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runHook(t *testing.T, bash, hookPath, dir string) string {
+	t.Helper()
+	cmd := exec.Command(bash, hookPath)
+	cmd.Dir = dir
+	out, _ := cmd.CombinedOutput() // non-zero exit is expected when violations exist
+	return string(out)
+}


### PR DESCRIPTION
## The bug
The scaffolded **pre-commit hook** (`internal/workflow/templates.go`, PowerShell + Bash) listed `.cs`, `.java`, `.py`, `.rs` as source extensions but only knew how to locate a **Go** (`_test.go`) or **JS/TS** (`.test`/`.spec`) test file. For every other language it computed a JS-style expected name (e.g. `Foo.test.cs`) that never matches real conventions.

Result in a C# repo (which uses `FooTests.cs`):
- **every** new source file was flagged *"no corresponding test file"* → forced `git commit --no-verify`
- the `FooTests.cs` test file itself was *also* flagged as untested source

## The fix
Per-language test candidates, searched **repo-wide** (test projects/dirs are common):

| Language | Recognized test conventions |
|---|---|
| Go | `<name>_test.go` |
| JS/TS | `<name>.test.*` / `<name>.spec.*` |
| Python | `test_<name>.py` / `<name>_test.py` |
| Rust | `<name>_test.rs` **or** inline `#[cfg(test)]` |
| C# | `<name>Tests.cs` / `<name>Test.cs` / `<name>.Tests.cs` |
| Java | `<name>Test.java` / `<name>Tests.java` / `<name>IT.java` |

The "is this file itself a test?" exclusion was widened to match, so a new test file is never flagged.

## Tests (Red → Green)
`templates_testgate_test.go`: content assertions over **both** hook variants, plus a **behavioural** test that *executes* the rendered Bash hook in a throwaway git repo — proving a lone `Calculator.cs` is flagged and adding `CalculatorTests.cs` satisfies the gate. Full `internal/workflow` package green; `go vet` + `go build` clean.

## Scope
Applies to newly scaffolded repos and any repo that re-runs `scripts/install-workflow-hooks.{ps1,sh}`. An **already-installed** buggy hook must be regenerated to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)